### PR TITLE
Add embeddings as options for similarity measure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `embedding` and `embedding_large` as new `similarity_measure` options
+
 ## [1.0.3] - 2025-02-19
 
 ### Added

--- a/src/cleanlab_tlm/internal/constants.py
+++ b/src/cleanlab_tlm/internal/constants.py
@@ -32,7 +32,12 @@ _TLM_MAX_TOKEN_RANGE: dict[str, tuple[int, int]] = {  # model: (min, max)
 TLM_CONSTRAIN_OUTPUTS_KEY: str = "constrain_outputs"
 TLM_NUM_CANDIDATE_RESPONSES_RANGE: tuple[int, int] = (1, 20)  # (min, max)
 TLM_NUM_CONSISTENCY_SAMPLES_RANGE: tuple[int, int] = (0, 20)  # (min, max)
-TLM_SIMILARITY_MEASURES: set[str] = {"semantic", "string"}
+TLM_SIMILARITY_MEASURES: set[str] = {
+    "semantic",
+    "string",
+    "embedding",
+    "embedding_large",
+}
 TLM_REASONING_EFFORT_VALUES: set[str] = {"none", "low", "medium", "high"}
 TLM_VALID_LOG_OPTIONS: set[str] = {"perplexity", "explanation"}
 TLM_VALID_GET_TRUSTWORTHINESS_SCORE_KWARGS: set[str] = {

--- a/src/cleanlab_tlm/tlm.py
+++ b/src/cleanlab_tlm/tlm.py
@@ -859,9 +859,10 @@ class TLMOptions(TypedDict):
         Self-reflection helps quantify aleatoric uncertainty associated with challenging prompts
         and catches answers that are obviously incorrect/bad.
 
-        similarity_measure ({"semantic", "string"}, default = "semantic"): how the trustworthiness scoring algorithm measures
+        similarity_measure ({"semantic", "string", "embedding", "embedding_large"}, default = "semantic"): how the trustworthiness scoring algorithm measures
         similarity between sampled responses considered by the model in the consistency assessment.
-        Supported similarity measures include "semantic" (based on natural language inference) and "string" (based on character/word overlap).
+        Supported similarity measures include "semantic" (based on natural language inference), "string" (based on character/word overlap),
+        "embedding" (based on embedding similarity), and "embedding_large" (based on embedding similarity with a larger embedding model).
         Set this to "string" to improve latency/costs.
 
         reasoning_effort ({"none", "low", "medium", "high"}, default = "high"): how much the LLM can reason (number of thinking tokens)


### PR DESCRIPTION
Adds two new `similarity_measure` options: `embedding` and `embedding_large`