### PR TITLE
Add task argument during TLM initialization

### DIFF
--- a/src/cleanlab_tlm/internal/api/api.py
+++ b/src/cleanlab_tlm/internal/api/api.py
@@ -184,6 +184,7 @@ async def tlm_prompt(
     api_key: str,
     prompt: str,
     quality_preset: str,
+    task: str,
     options: Optional[JSONDict],
     rate_handler: TlmRateHandler,
     client_session: Optional[aiohttp.ClientSession] = None,
@@ -197,6 +198,7 @@ async def tlm_prompt(
         api_key (str): API key for auth
         prompt (str): prompt for TLM to respond to
         quality_preset (str): quality preset to use to generate response
+        task (str): task type for evaluation
         options (JSONDict): additional parameters for TLM
         rate_handler (TlmRateHandler): concurrency handler used to manage TLM request rate
         client_session (aiohttp.ClientSession): client session used to issue TLM request
@@ -218,6 +220,7 @@ async def tlm_prompt(
                 json={
                     "prompt": prompt,
                     "quality": quality_preset,
+                    "task": task,
                     "options": options or {},
                     "user_id": api_key,
                     "client_id": api_key,
@@ -248,6 +251,7 @@ async def tlm_get_confidence_score(
     prompt: str,
     response: dict[str, Any],
     quality_preset: str,
+    task: str,
     options: Optional[JSONDict],
     rate_handler: TlmRateHandler,
     client_session: Optional[aiohttp.ClientSession] = None,
@@ -261,6 +265,7 @@ async def tlm_get_confidence_score(
         prompt (str): prompt for TLM to get confidence score for
         response (Dict[str, Any]): dictionary containing response and optional metadata
         quality_preset (str): quality preset to use to generate confidence score
+        task (str): task type for evaluation
         options (JSONDict): additional parameters for TLM
         rate_handler (TlmRateHandler): concurrency handler used to manage TLM request rate
         client_session (aiohttp.ClientSession): client session used to issue TLM request
@@ -282,6 +287,7 @@ async def tlm_get_confidence_score(
                     "prompt": prompt,
                     "response": response,
                     "quality": quality_preset,
+                    "task": task,
                     "options": options or {},
                 },
                 headers=_construct_headers(api_key),

--- a/src/cleanlab_tlm/internal/constants.py
+++ b/src/cleanlab_tlm/internal/constants.py
@@ -26,9 +26,9 @@ _VALID_TLM_MODELS: list[str] = [
 ]
 _TLM_DEFAULT_MODEL: str = "gpt-4o-mini"
 _VALID_TLM_TASKS: set[str] = {task.value for task in Task}
-TLM_TASK_SUPPORTING_CONSTRAIN_OUTPUTS: set[str] = {
-    Task.DEFAULT.value,
-    Task.CLASSIFICATION.value,
+TLM_TASK_SUPPORTING_CONSTRAIN_OUTPUTS: set[Task] = {
+    Task.DEFAULT,
+    Task.CLASSIFICATION,
 }
 _TLM_MAX_RETRIES: int = 3  # TODO: finalize this number
 _TLM_MAX_TOKEN_RANGE: dict[str, tuple[int, int]] = {  # model: (min, max)

--- a/src/cleanlab_tlm/internal/constants.py
+++ b/src/cleanlab_tlm/internal/constants.py
@@ -1,3 +1,5 @@
+from cleanlab_tlm.internal.types import Task
+
 # TLM constants
 # prepend constants with _ so that they don't show up in help.cleanlab.ai docs
 _VALID_TLM_QUALITY_PRESETS: list[str] = ["best", "high", "medium", "low", "base"]
@@ -23,8 +25,11 @@ _VALID_TLM_MODELS: list[str] = [
     "nova-pro",
 ]
 _TLM_DEFAULT_MODEL: str = "gpt-4o-mini"
-_VALID_TLM_TASKS: set[str] = {"default", "classification", "code_generation"}
-TLM_TASK_SUPPORTING_CONSTRAIN_OUTPUTS: set[str] = {"default", "classification"}
+_VALID_TLM_TASKS: set[str] = {task.value for task in Task}
+TLM_TASK_SUPPORTING_CONSTRAIN_OUTPUTS: set[str] = {
+    Task.DEFAULT.value,
+    Task.CLASSIFICATION.value,
+}
 _TLM_MAX_RETRIES: int = 3  # TODO: finalize this number
 _TLM_MAX_TOKEN_RANGE: dict[str, tuple[int, int]] = {  # model: (min, max)
     "default": (64, 4096),

--- a/src/cleanlab_tlm/internal/constants.py
+++ b/src/cleanlab_tlm/internal/constants.py
@@ -24,6 +24,7 @@ _VALID_TLM_MODELS: list[str] = [
 ]
 _TLM_DEFAULT_MODEL: str = "gpt-4o-mini"
 _VALID_TLM_TASKS: set[str] = {"default", "classification", "code_generation"}
+TLM_TASK_SUPPORTING_CONSTRAIN_OUTPUTS: set[str] = {"default", "classification"}
 _TLM_MAX_RETRIES: int = 3  # TODO: finalize this number
 _TLM_MAX_TOKEN_RANGE: dict[str, tuple[int, int]] = {  # model: (min, max)
     "default": (64, 4096),

--- a/src/cleanlab_tlm/internal/constants.py
+++ b/src/cleanlab_tlm/internal/constants.py
@@ -23,6 +23,7 @@ _VALID_TLM_MODELS: list[str] = [
     "nova-pro",
 ]
 _TLM_DEFAULT_MODEL: str = "gpt-4o-mini"
+_VALID_TLM_TASKS: set[str] = {"default", "classification", "code_generation"}
 _TLM_MAX_RETRIES: int = 3  # TODO: finalize this number
 _TLM_MAX_TOKEN_RANGE: dict[str, tuple[int, int]] = {  # model: (min, max)
     "default": (64, 4096),

--- a/src/cleanlab_tlm/internal/types.py
+++ b/src/cleanlab_tlm/internal/types.py
@@ -1,5 +1,15 @@
+from enum import Enum
 from typing import Any, Literal
 
 TLMQualityPreset = Literal["best", "high", "medium", "low", "base"]
+
+
+class Task(str, Enum):
+    """Enum for TLM task types."""
+
+    DEFAULT = "default"
+    CLASSIFICATION = "classification"
+    CODE_GENERATION = "code_generation"
+
 
 JSONDict = dict[str, Any]

--- a/src/cleanlab_tlm/internal/validation.py
+++ b/src/cleanlab_tlm/internal/validation.py
@@ -14,6 +14,7 @@ from cleanlab_tlm.internal.constants import (
     TLM_NUM_CONSISTENCY_SAMPLES_RANGE,
     TLM_REASONING_EFFORT_VALUES,
     TLM_SIMILARITY_MEASURES,
+    TLM_TASK_SUPPORTING_CONSTRAIN_OUTPUTS,
     TLM_VALID_GET_TRUSTWORTHINESS_SCORE_KWARGS,
     TLM_VALID_LOG_OPTIONS,
     TLM_VALID_PROMPT_KWARGS,
@@ -181,12 +182,15 @@ def process_and_validate_kwargs_constrain_outputs(
     kwargs_dict: dict[str, Any],
     response: Optional[Union[str, Sequence[str]]] = None,
 ) -> None:
-    if task == "classification" and _TLM_CONSTRAIN_OUTPUTS_KEY not in kwargs_dict:
-        raise ValidationError("constrain_outputs must be provided for classification tasks")
-
     constrain_outputs = kwargs_dict.get(_TLM_CONSTRAIN_OUTPUTS_KEY)
     if constrain_outputs is None:
+        if task == "classification":
+            raise ValidationError("constrain_outputs must be provided for classification tasks")
+
         return
+
+    if task not in TLM_TASK_SUPPORTING_CONSTRAIN_OUTPUTS:
+        raise ValidationError("constrain_outputs is only supported for classification tasks")
 
     if isinstance(prompt, str):
         if not isinstance(constrain_outputs, list) or not all(isinstance(s, str) for s in constrain_outputs):

--- a/src/cleanlab_tlm/internal/validation.py
+++ b/src/cleanlab_tlm/internal/validation.py
@@ -4,6 +4,7 @@ from typing import Any, Optional, Union
 
 from cleanlab_tlm.errors import ValidationError
 from cleanlab_tlm.internal.constants import (
+    _TLM_CONSTRAIN_OUTPUTS_KEY,
     _TLM_DEFAULT_MODEL,
     _TLM_MAX_TOKEN_RANGE,
     _VALID_TLM_MODELS,
@@ -176,10 +177,14 @@ def validate_tlm_options(options: Any) -> None:
 
 def process_and_validate_kwargs_constrain_outputs(
     prompt: Union[str, Sequence[str]],
+    task: str,
     kwargs_dict: dict[str, Any],
     response: Optional[Union[str, Sequence[str]]] = None,
 ) -> None:
-    constrain_outputs = kwargs_dict.get("constrain_outputs")
+    if task == "classification" and _TLM_CONSTRAIN_OUTPUTS_KEY not in kwargs_dict:
+        raise ValidationError("constrain_outputs must be provided for classification tasks")
+
+    constrain_outputs = kwargs_dict.get(_TLM_CONSTRAIN_OUTPUTS_KEY)
     if constrain_outputs is None:
         return
 
@@ -216,11 +221,12 @@ def process_and_validate_kwargs_constrain_outputs(
                         f"Response '{resp}' at index {i} must be one of the constraint outputs: {constraints}"
                     )
 
-    kwargs_dict["constrain_outputs"] = constrain_outputs
+    kwargs_dict[_TLM_CONSTRAIN_OUTPUTS_KEY] = constrain_outputs
 
 
 def tlm_prompt_process_and_validate_kwargs(
     prompt: Union[str, Sequence[str]],
+    task: str,
     kwargs_dict: dict[str, Any],
 ) -> None:
     if not SKIP_VALIDATE_TLM_OPTIONS:
@@ -232,15 +238,16 @@ def tlm_prompt_process_and_validate_kwargs(
                 f"Supported keyword arguments are: {supported_kwargs}"
             )
 
-    process_and_validate_kwargs_constrain_outputs(prompt=prompt, kwargs_dict=kwargs_dict)
+    process_and_validate_kwargs_constrain_outputs(prompt=prompt, task=task, kwargs_dict=kwargs_dict)
 
 
 def tlm_score_process_response_and_kwargs(
     prompt: Union[str, Sequence[str]],
     response: Union[str, Sequence[str]],
+    task: str,
     kwargs_dict: dict[str, Any],
 ) -> Union[dict[str, Any], list[dict[str, Any]]]:
-    process_and_validate_kwargs_constrain_outputs(prompt=prompt, kwargs_dict=kwargs_dict, response=response)
+    process_and_validate_kwargs_constrain_outputs(prompt=prompt, task=task, kwargs_dict=kwargs_dict, response=response)
 
     if not SKIP_VALIDATE_TLM_OPTIONS:
         invalid_kwargs = set(kwargs_dict.keys()) - TLM_VALID_GET_TRUSTWORTHINESS_SCORE_KWARGS

--- a/src/cleanlab_tlm/internal/validation.py
+++ b/src/cleanlab_tlm/internal/validation.py
@@ -20,6 +20,7 @@ from cleanlab_tlm.internal.constants import (
     TLM_VALID_PROMPT_KWARGS,
     VALID_RESPONSE_OPTIONS,
 )
+from cleanlab_tlm.internal.types import Task
 
 SKIP_VALIDATE_TLM_OPTIONS: bool = os.environ.get("CLEANLAB_TLM_SKIP_VALIDATE_TLM_OPTIONS", "false").lower() == "true"
 
@@ -178,13 +179,13 @@ def validate_tlm_options(options: Any) -> None:
 
 def process_and_validate_kwargs_constrain_outputs(
     prompt: Union[str, Sequence[str]],
-    task: str,
+    task: Task,
     kwargs_dict: dict[str, Any],
     response: Optional[Union[str, Sequence[str]]] = None,
 ) -> None:
     constrain_outputs = kwargs_dict.get(_TLM_CONSTRAIN_OUTPUTS_KEY)
     if constrain_outputs is None:
-        if task == "classification":
+        if task == Task.CLASSIFICATION:
             raise ValidationError("constrain_outputs must be provided for classification tasks")
 
         return
@@ -230,7 +231,7 @@ def process_and_validate_kwargs_constrain_outputs(
 
 def tlm_prompt_process_and_validate_kwargs(
     prompt: Union[str, Sequence[str]],
-    task: str,
+    task: Task,
     kwargs_dict: dict[str, Any],
 ) -> None:
     if not SKIP_VALIDATE_TLM_OPTIONS:
@@ -248,7 +249,7 @@ def tlm_prompt_process_and_validate_kwargs(
 def tlm_score_process_response_and_kwargs(
     prompt: Union[str, Sequence[str]],
     response: Union[str, Sequence[str]],
-    task: str,
+    task: Task,
     kwargs_dict: dict[str, Any],
 ) -> Union[dict[str, Any], list[dict[str, Any]]]:
     process_and_validate_kwargs_constrain_outputs(prompt=prompt, task=task, kwargs_dict=kwargs_dict, response=response)

--- a/src/cleanlab_tlm/tlm.py
+++ b/src/cleanlab_tlm/tlm.py
@@ -46,6 +46,7 @@ from cleanlab_tlm.internal.constants import (
     _VALID_TLM_QUALITY_PRESETS,
     _VALID_TLM_TASKS,
 )
+from cleanlab_tlm.internal.types import Task
 from cleanlab_tlm.internal.validation import (
     tlm_prompt_process_and_validate_kwargs,
     tlm_score_process_response_and_kwargs,
@@ -252,7 +253,7 @@ class TLM:
         self._options = {"model": _TLM_DEFAULT_MODEL, **options_dict}
 
         self._quality_preset = quality_preset
-        self._task = task
+        self._task = Task(task)
 
         if timeout is not None and not (isinstance(timeout, (float, int))):
             raise ValidationError("timeout must be a integer or float value")
@@ -583,7 +584,7 @@ class TLM:
                 self._api_key,
                 prompt,
                 self._quality_preset,
-                self._task,
+                self._task.value,
                 self._options,
                 self._rate_handler,
                 client_session,
@@ -767,7 +768,7 @@ class TLM:
                 prompt,
                 response,
                 self._quality_preset,
-                self._task,
+                self._task.value,
                 self._options,
                 self._rate_handler,
                 client_session,

--- a/src/cleanlab_tlm/tlm.py
+++ b/src/cleanlab_tlm/tlm.py
@@ -195,7 +195,7 @@ class TLM:
         task ({"default", "classification", "code_generation"}, default = "default"): determines which scoring flow/methodology to use for evaluating the trustworthiness of the response.
             - "default": use for general tasks such as QA, summarization, etc.
             - "classification": use for classification tasks, where the response is a categorical prediction. \
-                Note that `constrain_outputs` must be provided in the `prompt()` and `get_trustworthiness_score()` methods for classification tasks.
+                When using this task type, `constrain_outputs` must be provided in the `prompt()` and `get_trustworthiness_score()` methods.
             - "code_generation": use for code generation tasks.
 
         options (TLMOptions, optional): a typed dict of advanced configurations you can optionally specify.

--- a/src/cleanlab_tlm/tlm.py
+++ b/src/cleanlab_tlm/tlm.py
@@ -44,6 +44,7 @@ from cleanlab_tlm.internal.constants import (
     _TLM_DEFAULT_MODEL,
     _TLM_MAX_RETRIES,
     _VALID_TLM_QUALITY_PRESETS,
+    _VALID_TLM_TASKS,
 )
 from cleanlab_tlm.internal.validation import (
     tlm_prompt_process_and_validate_kwargs,
@@ -191,6 +192,12 @@ class TLM:
             Avoid "best" or "high" presets if you just want trustworthiness scores (i.e. are using `tlm.get_trustworthiness_score()` rather than `tlm.prompt()`).
             These "best" or "high" presets can additionally improve the LLM response itself, but do not return more reliable trustworthiness scores than "medium" or "low" presets.
 
+        task ({"default", "classification", "code_generation"}, default = "default"): determines which scoring flow/methodology to use for evaluating the trustworthiness of the response.
+            - "default": use for general tasks such as QA, summarization, etc.
+            - "classification": use for classification tasks, where the response is a categorical prediction. \
+                Note that `constrain_outputs` must be provided in the `prompt()` and `get_trustworthiness_score()` methods for classification tasks.
+            - "code_generation": use for code generation tasks.
+
         options (TLMOptions, optional): a typed dict of advanced configurations you can optionally specify.
         Available options (keys in this dict) include "model", "max_tokens", "num_candidate_responses", "num_consistency_samples", "use_self_reflection",
         "similarity_measure", "reasoning_effort", "log", "custom_eval_criteria".
@@ -210,6 +217,7 @@ class TLM:
         self,
         quality_preset: TLMQualityPreset = "medium",
         *,
+        task: str = "default",
         api_key: Optional[str] = None,
         options: Optional[TLMOptions] = None,
         timeout: Optional[float] = None,
@@ -227,6 +235,9 @@ class TLM:
                 f"Invalid quality preset {quality_preset} -- must be one of {_VALID_TLM_QUALITY_PRESETS}"
             )
 
+        if task not in _VALID_TLM_TASKS:
+            raise ValidationError(f"Invalid task {task} -- must be one of {_VALID_TLM_TASKS}")
+
         self._return_log = False
 
         options_dict = options or {}
@@ -241,6 +252,7 @@ class TLM:
         self._options = {"model": _TLM_DEFAULT_MODEL, **options_dict}
 
         self._quality_preset = quality_preset
+        self._task = task
 
         if timeout is not None and not (isinstance(timeout, (float, int))):
             raise ValidationError("timeout must be a integer or float value")
@@ -431,7 +443,7 @@ class TLM:
                 Use the [`try_prompt()`](#method-try_prompt) method instead and run it on multiple smaller batches.
         """
         validate_tlm_prompt(prompt)
-        tlm_prompt_process_and_validate_kwargs(prompt, kwargs)
+        tlm_prompt_process_and_validate_kwargs(prompt, self._task, kwargs)
         if isinstance(prompt, str):
             return cast(
                 TLMResponse,
@@ -484,7 +496,7 @@ class TLM:
                 use [`prompt()`](#method-prompt) instead.
         """
         validate_tlm_try_prompt(prompt)
-        tlm_prompt_process_and_validate_kwargs(prompt, kwargs)
+        tlm_prompt_process_and_validate_kwargs(prompt, self._task, kwargs)
 
         return self._event_loop.run_until_complete(
             self._batch_prompt(
@@ -521,7 +533,7 @@ class TLM:
                 This method will raise an exception if any errors occur or if you hit a timeout (given a timeout is specified).
         """
         validate_tlm_prompt(prompt)
-        tlm_prompt_process_and_validate_kwargs(prompt, kwargs)
+        tlm_prompt_process_and_validate_kwargs(prompt, self._task, kwargs)
 
         async with aiohttp.ClientSession() as session:
             if isinstance(prompt, str):
@@ -571,6 +583,7 @@ class TLM:
                 self._api_key,
                 prompt,
                 self._quality_preset,
+                self._task,
                 self._options,
                 self._rate_handler,
                 client_session,
@@ -617,7 +630,7 @@ class TLM:
                 For big datasets, we recommend using [`try_get_trustworthiness_score()`](#method-try_get_trustworthiness_score) instead, and running it in multiple batches.
         """
         validate_tlm_prompt_response(prompt, response)
-        processed_response = tlm_score_process_response_and_kwargs(prompt, response, kwargs)
+        processed_response = tlm_score_process_response_and_kwargs(prompt, response, self._task, kwargs)
 
         if isinstance(prompt, str) and isinstance(processed_response, dict):
             return cast(
@@ -670,7 +683,7 @@ class TLM:
                 use the [`get_trustworthiness_score()`](#method-get_trustworthiness_score) method instead.
         """
         validate_try_tlm_prompt_response(prompt, response)
-        processed_response = tlm_score_process_response_and_kwargs(prompt, response, kwargs)
+        processed_response = tlm_score_process_response_and_kwargs(prompt, response, self._task, kwargs)
 
         assert isinstance(processed_response, list)
 
@@ -708,7 +721,7 @@ class TLM:
                 This method will raise an exception if any errors occur or if you hit a timeout (given a timeout is specified).
         """
         validate_tlm_prompt_response(prompt, response)
-        processed_response = tlm_score_process_response_and_kwargs(prompt, response, kwargs)
+        processed_response = tlm_score_process_response_and_kwargs(prompt, response, self._task, kwargs)
 
         async with aiohttp.ClientSession() as session:
             if isinstance(prompt, str) and isinstance(processed_response, dict):
@@ -754,6 +767,7 @@ class TLM:
                 prompt,
                 response,
                 self._quality_preset,
+                self._task,
                 self._options,
                 self._rate_handler,
                 client_session,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ from cleanlab_tlm.internal.constants import (
     _TLM_DEFAULT_MODEL,
     _TLM_MAX_TOKEN_RANGE,
     _VALID_TLM_MODELS,
+    _VALID_TLM_TASKS,
     TLM_MODELS_NOT_SUPPORTING_EXPLANATION,
     TLM_REASONING_EFFORT_VALUES,
     TLM_SIMILARITY_MEASURES,
@@ -60,14 +61,17 @@ def tlm_dict(tlm_api_key: str) -> dict[str, Any]:
         tlm_dict[quality_preset] = {}
         for model in _VALID_TLM_MODELS:
             tlm_dict[quality_preset][model] = {}
+            task = random.choice(list(_VALID_TLM_TASKS))
             options = _get_options_dictionary(model)
             tlm_dict[quality_preset][model]["tlm"] = TLM(
                 quality_preset=quality_preset,
+                task=task,
                 api_key=tlm_api_key,
                 options=options,
             )
             tlm_dict[quality_preset][model]["tlm_no_options"] = TLM(
                 quality_preset=quality_preset,
+                task=task,
                 api_key=tlm_api_key,
             )
             tlm_dict[quality_preset][model]["options"] = options

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -8,6 +8,8 @@ TEST_PROMPT_BATCH: list[str] = [
     "What is the capital of Ukraine?",
 ]
 TEST_RESPONSE_BATCH: list[str] = ["Paris", "Kyiv"]
+TEST_CONSTRAIN_OUTPUTS_BINARY = ["Paris", "Kyiv"]
+TEST_CONSTRAIN_OUTPUTS = ["Paris", "Kyiv", "London", "New York"]
 
 # Test validation tests for TLM
 MAX_PROMPT_LENGTH_TOKENS: int = 70_000

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -8,6 +8,8 @@ from cleanlab_tlm.tlm import TLM
 from tests.conftest import make_text_unique
 from tests.constants import (
     MODELS_WITH_NO_PERPLEXITY_SCORE,
+    TEST_CONSTRAIN_OUTPUTS,
+    TEST_CONSTRAIN_OUTPUTS_BINARY,
     TEST_PROMPT,
     TEST_PROMPT_BATCH,
     TEST_RESPONSE,
@@ -177,17 +179,20 @@ def _test_batch_get_trustworthiness_score_response(
 
 
 @pytest.mark.asyncio(scope="function")
-async def _run_prompt_async(tlm: TLM, prompt: Union[list[str], str]) -> Any:
+async def _run_prompt_async(tlm: TLM, prompt: Union[list[str], str], **kwargs: Any) -> Any:
     """Runs tlm.prompt() asynchronously."""
-    return await tlm.prompt_async(prompt)
+    return await tlm.prompt_async(prompt, **kwargs)
 
 
 @pytest.mark.asyncio(scope="function")
 async def _run_get_trustworthiness_score_async(
-    tlm: TLM, prompt: Union[list[str], str], response: Union[list[str], str]
+    tlm: TLM,
+    prompt: Union[list[str], str],
+    response: Union[list[str], str],
+    **kwargs: Any,
 ) -> Any:
     """Runs tlm.get_trustworthiness_score asynchronously."""
-    return await tlm.get_trustworthiness_score_async(prompt, response)
+    return await tlm.get_trustworthiness_score_async(prompt, response, **kwargs)
 
 
 @pytest.mark.parametrize("model", VALID_TLM_MODELS)
@@ -205,7 +210,10 @@ def test_prompt(tlm_dict: dict[str, Any], model: str, quality_preset: str) -> No
     print("TLM Options for run:", options)
 
     # test prompt with single prompt
-    response = tlm_no_options.prompt(test_prompt_single)
+    tlm_no_options_kwargs = {}
+    if tlm_no_options._task == "classification":
+        tlm_no_options_kwargs["constrain_outputs"] = TEST_CONSTRAIN_OUTPUTS_BINARY
+    response = tlm_no_options.prompt(test_prompt_single, **tlm_no_options_kwargs)
     print("TLM Single Response:", response)
     _test_prompt_response(
         response,
@@ -214,7 +222,10 @@ def test_prompt(tlm_dict: dict[str, Any], model: str, quality_preset: str) -> No
     )
 
     # test prompt with batch prompt
-    responses = tlm.prompt(test_prompt_batch)
+    tlm_kwargs = {}
+    if tlm._task == "classification":
+        tlm_kwargs["constrain_outputs"] = TEST_CONSTRAIN_OUTPUTS
+    responses = tlm.prompt(test_prompt_batch, **tlm_kwargs)
     print("TLM Batch Responses:", responses)
     _test_batch_prompt_response(
         responses,
@@ -238,12 +249,18 @@ def test_prompt_async(tlm_dict: dict[str, Any], model: str, quality_preset: str)
     print("TLM Options for run:", options)
 
     # test prompt with single prompt
-    response = asyncio.run(_run_prompt_async(tlm_no_options, test_prompt_single))
+    tlm_no_options_kwargs = {}
+    if tlm_no_options._task == "classification":
+        tlm_no_options_kwargs["constrain_outputs"] = TEST_CONSTRAIN_OUTPUTS_BINARY
+    response = asyncio.run(_run_prompt_async(tlm_no_options, test_prompt_single, **tlm_no_options_kwargs))
     print("TLM Single Response:", response)
     _test_prompt_response(response, {}, allow_null_trustworthiness_score=allow_null_trustworthiness_score)
 
     # test prompt with batch prompt
-    responses = asyncio.run(_run_prompt_async(tlm, test_prompt_batch))
+    tlm_kwargs = {}
+    if tlm._task == "classification":
+        tlm_kwargs["constrain_outputs"] = TEST_CONSTRAIN_OUTPUTS
+    responses = asyncio.run(_run_prompt_async(tlm, test_prompt_batch, **tlm_kwargs))
     print("TLM Batch Responses:", responses)
     _test_batch_prompt_response(
         responses,
@@ -264,7 +281,10 @@ def test_try_prompt(tlm_dict: dict[str, Any], model: str, quality_preset: str) -
     print("TLM Options for run: None.")
 
     # test prompt with batch prompt
-    responses = tlm_no_options.try_prompt(test_prompt_batch)
+    tlm_no_options_kwargs = {}
+    if tlm_no_options._task == "classification":
+        tlm_no_options_kwargs["constrain_outputs"] = TEST_CONSTRAIN_OUTPUTS
+    responses = tlm_no_options.try_prompt(test_prompt_batch, **tlm_no_options_kwargs)
     print("TLM Batch Responses:", responses)
     _test_batch_prompt_response(
         responses,
@@ -288,12 +308,18 @@ def test_get_trustworthiness_score(tlm_dict: dict[str, Any], model: str, quality
     print("TLM Options for run:", options)
 
     # test prompt with single prompt
-    response = tlm.get_trustworthiness_score(test_prompt_single, TEST_RESPONSE)
+    tlm_no_options_kwargs = {}
+    if tlm_no_options._task == "classification":
+        tlm_no_options_kwargs["constrain_outputs"] = TEST_CONSTRAIN_OUTPUTS_BINARY
+    response = tlm_no_options.get_trustworthiness_score(test_prompt_single, TEST_RESPONSE, **tlm_no_options_kwargs)
     print("TLM Single Response:", response)
     _test_get_trustworthiness_score_response(response, options, quality_preset)
 
     # test prompt with batch prompt
-    responses = tlm_no_options.get_trustworthiness_score(test_prompt_batch, TEST_RESPONSE_BATCH)
+    tlm_kwargs = {}
+    if tlm._task == "classification":
+        tlm_kwargs["constrain_outputs"] = TEST_CONSTRAIN_OUTPUTS
+    responses = tlm.get_trustworthiness_score(test_prompt_batch, TEST_RESPONSE_BATCH, **tlm_kwargs)
     print("TLM Batch Responses:", responses)
     _test_batch_get_trustworthiness_score_response(responses, {}, quality_preset)
 
@@ -312,16 +338,25 @@ def test_get_trustworthiness_score_async(tlm_dict: dict[str, Any], model: str, q
     print("TLM Options for run:", options)
 
     # test prompt with single prompt
-    response = asyncio.run(_run_get_trustworthiness_score_async(tlm_no_options, test_prompt_single, TEST_RESPONSE))
+    tlm_no_options_kwargs = {}
+    if tlm_no_options._task == "classification":
+        tlm_no_options_kwargs["constrain_outputs"] = TEST_CONSTRAIN_OUTPUTS_BINARY
+    response = asyncio.run(
+        _run_get_trustworthiness_score_async(tlm_no_options, test_prompt_single, TEST_RESPONSE, **tlm_no_options_kwargs)
+    )
     print("TLM Single Response:", response)
     _test_get_trustworthiness_score_response(response, {}, quality_preset)
 
     # test prompt with batch prompt
+    tlm_kwargs = {}
+    if tlm._task == "classification":
+        tlm_kwargs["constrain_outputs"] = TEST_CONSTRAIN_OUTPUTS
     responses = asyncio.run(
         _run_get_trustworthiness_score_async(
             tlm,
             test_prompt_batch,
             TEST_RESPONSE_BATCH,
+            **tlm_kwargs,
         )
     )
     print("TLM Batch Responses:", responses)
@@ -340,6 +375,9 @@ def test_try_get_trustworthiness_score(tlm_dict: dict[str, Any], model: str, qua
     print("TLM Options for run:", options)
 
     # test prompt with batch prompt
-    responses = tlm.try_get_trustworthiness_score(test_prompt_batch, TEST_RESPONSE_BATCH)
+    tlm_kwargs = {}
+    if tlm._task == "classification":
+        tlm_kwargs["constrain_outputs"] = TEST_CONSTRAIN_OUTPUTS
+    responses = tlm.try_get_trustworthiness_score(test_prompt_batch, TEST_RESPONSE_BATCH, **tlm_kwargs)
     print("TLM Batch Responses:", responses)
     _test_batch_get_trustworthiness_score_response(responses, options, quality_preset)

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -4,6 +4,7 @@ from typing import Any, Union
 import pytest
 
 from cleanlab_tlm.internal.constants import _VALID_TLM_QUALITY_PRESETS
+from cleanlab_tlm.internal.types import Task
 from cleanlab_tlm.tlm import TLM
 from tests.conftest import make_text_unique
 from tests.constants import (
@@ -211,7 +212,7 @@ def test_prompt(tlm_dict: dict[str, Any], model: str, quality_preset: str) -> No
 
     # test prompt with single prompt
     tlm_no_options_kwargs = {}
-    if tlm_no_options._task == "classification":
+    if tlm_no_options._task == Task.CLASSIFICATION:
         tlm_no_options_kwargs["constrain_outputs"] = TEST_CONSTRAIN_OUTPUTS_BINARY
     response = tlm_no_options.prompt(test_prompt_single, **tlm_no_options_kwargs)
     print("TLM Single Response:", response)
@@ -223,7 +224,7 @@ def test_prompt(tlm_dict: dict[str, Any], model: str, quality_preset: str) -> No
 
     # test prompt with batch prompt
     tlm_kwargs = {}
-    if tlm._task == "classification":
+    if tlm._task == Task.CLASSIFICATION:
         tlm_kwargs["constrain_outputs"] = TEST_CONSTRAIN_OUTPUTS
     responses = tlm.prompt(test_prompt_batch, **tlm_kwargs)
     print("TLM Batch Responses:", responses)
@@ -250,7 +251,7 @@ def test_prompt_async(tlm_dict: dict[str, Any], model: str, quality_preset: str)
 
     # test prompt with single prompt
     tlm_no_options_kwargs = {}
-    if tlm_no_options._task == "classification":
+    if tlm_no_options._task == Task.CLASSIFICATION:
         tlm_no_options_kwargs["constrain_outputs"] = TEST_CONSTRAIN_OUTPUTS_BINARY
     response = asyncio.run(_run_prompt_async(tlm_no_options, test_prompt_single, **tlm_no_options_kwargs))
     print("TLM Single Response:", response)
@@ -258,7 +259,7 @@ def test_prompt_async(tlm_dict: dict[str, Any], model: str, quality_preset: str)
 
     # test prompt with batch prompt
     tlm_kwargs = {}
-    if tlm._task == "classification":
+    if tlm._task == Task.CLASSIFICATION:
         tlm_kwargs["constrain_outputs"] = TEST_CONSTRAIN_OUTPUTS
     responses = asyncio.run(_run_prompt_async(tlm, test_prompt_batch, **tlm_kwargs))
     print("TLM Batch Responses:", responses)
@@ -282,7 +283,7 @@ def test_try_prompt(tlm_dict: dict[str, Any], model: str, quality_preset: str) -
 
     # test prompt with batch prompt
     tlm_no_options_kwargs = {}
-    if tlm_no_options._task == "classification":
+    if tlm_no_options._task == Task.CLASSIFICATION:
         tlm_no_options_kwargs["constrain_outputs"] = TEST_CONSTRAIN_OUTPUTS
     responses = tlm_no_options.try_prompt(test_prompt_batch, **tlm_no_options_kwargs)
     print("TLM Batch Responses:", responses)
@@ -309,7 +310,7 @@ def test_get_trustworthiness_score(tlm_dict: dict[str, Any], model: str, quality
 
     # test prompt with single prompt
     tlm_kwargs = {}
-    if tlm._task == "classification":
+    if tlm._task == Task.CLASSIFICATION:
         tlm_kwargs["constrain_outputs"] = TEST_CONSTRAIN_OUTPUTS_BINARY
     response = tlm.get_trustworthiness_score(test_prompt_single, TEST_RESPONSE, **tlm_kwargs)
     print("TLM Single Response:", response)
@@ -317,7 +318,7 @@ def test_get_trustworthiness_score(tlm_dict: dict[str, Any], model: str, quality
 
     # test prompt with batch prompt
     tlm_no_options_kwargs = {}
-    if tlm_no_options._task == "classification":
+    if tlm_no_options._task == Task.CLASSIFICATION:
         tlm_no_options_kwargs["constrain_outputs"] = TEST_CONSTRAIN_OUTPUTS
     responses = tlm_no_options.get_trustworthiness_score(
         test_prompt_batch, TEST_RESPONSE_BATCH, **tlm_no_options_kwargs
@@ -341,7 +342,7 @@ def test_get_trustworthiness_score_async(tlm_dict: dict[str, Any], model: str, q
 
     # test prompt with single prompt
     tlm_no_options_kwargs = {}
-    if tlm_no_options._task == "classification":
+    if tlm_no_options._task == Task.CLASSIFICATION:
         tlm_no_options_kwargs["constrain_outputs"] = TEST_CONSTRAIN_OUTPUTS_BINARY
     response = asyncio.run(
         _run_get_trustworthiness_score_async(tlm_no_options, test_prompt_single, TEST_RESPONSE, **tlm_no_options_kwargs)
@@ -351,7 +352,7 @@ def test_get_trustworthiness_score_async(tlm_dict: dict[str, Any], model: str, q
 
     # test prompt with batch prompt
     tlm_kwargs = {}
-    if tlm._task == "classification":
+    if tlm._task == Task.CLASSIFICATION:
         tlm_kwargs["constrain_outputs"] = TEST_CONSTRAIN_OUTPUTS
     responses = asyncio.run(
         _run_get_trustworthiness_score_async(
@@ -378,7 +379,7 @@ def test_try_get_trustworthiness_score(tlm_dict: dict[str, Any], model: str, qua
 
     # test prompt with batch prompt
     tlm_kwargs = {}
-    if tlm._task == "classification":
+    if tlm._task == Task.CLASSIFICATION:
         tlm_kwargs["constrain_outputs"] = TEST_CONSTRAIN_OUTPUTS
     responses = tlm.try_get_trustworthiness_score(test_prompt_batch, TEST_RESPONSE_BATCH, **tlm_kwargs)
     print("TLM Batch Responses:", responses)

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -308,18 +308,20 @@ def test_get_trustworthiness_score(tlm_dict: dict[str, Any], model: str, quality
     print("TLM Options for run:", options)
 
     # test prompt with single prompt
-    tlm_no_options_kwargs = {}
-    if tlm_no_options._task == "classification":
-        tlm_no_options_kwargs["constrain_outputs"] = TEST_CONSTRAIN_OUTPUTS_BINARY
-    response = tlm_no_options.get_trustworthiness_score(test_prompt_single, TEST_RESPONSE, **tlm_no_options_kwargs)
+    tlm_kwargs = {}
+    if tlm._task == "classification":
+        tlm_kwargs["constrain_outputs"] = TEST_CONSTRAIN_OUTPUTS_BINARY
+    response = tlm.get_trustworthiness_score(test_prompt_single, TEST_RESPONSE, **tlm_kwargs)
     print("TLM Single Response:", response)
     _test_get_trustworthiness_score_response(response, options, quality_preset)
 
     # test prompt with batch prompt
-    tlm_kwargs = {}
-    if tlm._task == "classification":
-        tlm_kwargs["constrain_outputs"] = TEST_CONSTRAIN_OUTPUTS
-    responses = tlm.get_trustworthiness_score(test_prompt_batch, TEST_RESPONSE_BATCH, **tlm_kwargs)
+    tlm_no_options_kwargs = {}
+    if tlm_no_options._task == "classification":
+        tlm_no_options_kwargs["constrain_outputs"] = TEST_CONSTRAIN_OUTPUTS
+    responses = tlm_no_options.get_trustworthiness_score(
+        test_prompt_batch, TEST_RESPONSE_BATCH, **tlm_no_options_kwargs
+    )
     print("TLM Batch Responses:", responses)
     _test_batch_get_trustworthiness_score_response(responses, {}, quality_preset)
 


### PR DESCRIPTION
Adds new task types for TLM which has its own default configs, can define by specifying:

```python
TLM(task="default")  # other available options include "classification", "code_generation"
```