### PR TITLE
add async score function to TrustworthyRAG module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.18] - 2025-04-11
+
+### Added
+
+- Add `score_async` method to TrustworthyRAG
+
 ## [1.0.16] - 2025-04-02
 
 ### Added
@@ -68,7 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `embedding` and `embedding_large` as new `similarity_measure` options
-- Add support for Claude 3.7 Sonnet 
+- Add support for Claude 3.7 Sonnet
 
 ## [1.0.3] - 2025-02-19
 
@@ -93,8 +99,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Release of the Cleanlab TLM Python client.
 
-[Unreleased]: https://github.com/cleanlab/cleanlab-tlm/compare/v1.0.17...HEAD
-[1.0.16]: https://github.com/cleanlab/cleanlab-tlm/compare/v1.0.16...v1.0.17
+[Unreleased]: https://github.com/cleanlab/cleanlab-tlm/compare/v1.0.18...HEAD
+[1.0.18]: https://github.com/cleanlab/cleanlab-tlm/compare/v1.0.17...v1.0.18
+[1.0.17]: https://github.com/cleanlab/cleanlab-tlm/compare/v1.0.16...v1.0.17
 [1.0.16]: https://github.com/cleanlab/cleanlab-tlm/compare/v1.0.15...v1.0.16
 [1.0.15]: https://github.com/cleanlab/cleanlab-tlm/compare/v1.0.14...v1.0.15
 [1.0.14]: https://github.com/cleanlab/cleanlab-tlm/compare/v1.0.13...v1.0.14

--- a/src/cleanlab_tlm/__about__.py
+++ b/src/cleanlab_tlm/__about__.py
@@ -1,2 +1,2 @@
 # SPDX-License-Identifier: MIT
-__version__ = "1.0.17"
+__version__ = "1.0.18"

--- a/src/cleanlab_tlm/utils/rag.py
+++ b/src/cleanlab_tlm/utils/rag.py
@@ -202,7 +202,7 @@ class TrustworthyRAG(BaseTLM):
         form_prompt: Optional[Callable[[str, str], str]] = None,
     ) -> Union[TrustworthyRAGScore, list[TrustworthyRAGScore]]:
         """
-        Evaluate an existing RAG system's response to a given user query and retrieved context.
+        Asynchronously evaluate an existing RAG system's response to a given user query and retrieved context.
 
         Args:
              response (str | Sequence[str]): A response (or list of multiple responses) from your LLM/RAG system.


### PR DESCRIPTION
## What changed?
Adds an async version of score function to `TrustworthyRAG`. This is needed for integrating Codex as Backup into Agility. Otherwise we get an error that the event loop is already running when calling `self._event_loop.run_until_complete()`

## What do you want the reviewer(s) to focus on?

---

### Checklist

- [ ] _Did you link the GitHub issue?_
- [ ] _Did you follow deployment steps or bump the version if needed?_
- [ ] _Did you add/update tests?_
- [ ] _What QA did you do?_
  - Tested...
