### PR TITLE
address bug where user accidentally provides list of list of Evals

### DIFF
--- a/src/cleanlab_tlm/utils/rag.py
+++ b/src/cleanlab_tlm/utils/rag.py
@@ -27,6 +27,7 @@ from typing import (
 from tqdm.asyncio import tqdm_asyncio
 from typing_extensions import NotRequired, TypedDict
 
+from cleanlab_tlm.errors import ValidationError
 from cleanlab_tlm.internal.api import api
 from cleanlab_tlm.internal.base import BaseTLM
 from cleanlab_tlm.internal.constants import (
@@ -124,9 +125,11 @@ class TrustworthyRAG(BaseTLM):
                 for eval_config in _DEFAULT_EVALS
             ]
         else:
+            # validate that evals is a list of Eval objects
+            if not isinstance(evals, list) or any(not isinstance(ev, Eval) for ev in evals):
+                raise ValidationError("'evals' must be a list of Eval objects")
+
             self._evals = evals
-            if (type(evals) is not list) or any([type(ev) is not Eval for ev in evals]):
-                raise ValueError("`evals` must be a list of Eval objects")
 
     def score(
         self,

--- a/src/cleanlab_tlm/utils/rag.py
+++ b/src/cleanlab_tlm/utils/rag.py
@@ -125,8 +125,7 @@ class TrustworthyRAG(BaseTLM):
             ]
         else:
             self._evals = evals
-            evals_are_invalid = any([type(ev) is not Eval for ev in evals])
-            if evals_are_invalid:
+            if (type(evals) is not list) or any([type(ev) is not Eval for ev in evals]):
                 raise ValueError("`evals` must be a list of Eval objects")
 
     def score(

--- a/src/cleanlab_tlm/utils/rag.py
+++ b/src/cleanlab_tlm/utils/rag.py
@@ -125,6 +125,9 @@ class TrustworthyRAG(BaseTLM):
             ]
         else:
             self._evals = evals
+            evals_are_invalid = any([type(ev) is not Eval for ev in evals])
+            if evals_are_invalid:
+                raise ValueError("`evals` must be a list of Eval objects")
 
     def score(
         self,


### PR DESCRIPTION
this is easy mistake to make, when you do:

```
evals = get_default_evals()
ev = [eval for eval in default_evals if eval.name == "response_helpfulness"]
trustworthy_rag = TrustworthyRAG(evals=[helpfulness])
```

I have NOT tested the code here works, just getting the fix started for you.

Would be good to also confirm you are validating the other input argument types properly? Eg. quality-preset, api-key, options, timeout, ...