### PR TITLE
Add simple getter methods to fetch defaults

### DIFF
--- a/src/cleanlab_tlm/internal/constants.py
+++ b/src/cleanlab_tlm/internal/constants.py
@@ -32,6 +32,7 @@ _VALID_TLM_MODELS: list[str] = [
     "nova-pro",
 ]
 _TLM_DEFAULT_MODEL: str = "gpt-4o-mini"
+_TLM_DEFAULT_CONTEXT_LIMIT: int = 70000
 _VALID_TLM_TASKS: set[str] = {task.value for task in Task}
 TLM_TASK_SUPPORTING_CONSTRAIN_OUTPUTS: set[Task] = {
     Task.DEFAULT,

--- a/src/cleanlab_tlm/utils/config.py
+++ b/src/cleanlab_tlm/utils/config.py
@@ -1,0 +1,22 @@
+from cleanlab_tlm.internal.constants import (
+    _TLM_DEFAULT_MODEL,
+    _DEFAULT_TLM_QUALITY_PRESET,
+)
+
+def get_default_model() -> str:
+    """
+    Get the default model name for TLM.
+
+    Returns:
+        str: The default model name for TLM.
+    """
+    return _TLM_DEFAULT_MODEL
+
+def get_default_quality_preset() -> str:
+    """
+    Get the default quality preset for TLM.
+
+    Returns:
+        str: The default quality preset for TLM.
+    """
+    return _DEFAULT_TLM_QUALITY_PRESET

--- a/src/cleanlab_tlm/utils/config.py
+++ b/src/cleanlab_tlm/utils/config.py
@@ -33,7 +33,7 @@ def get_default_context_limit() -> int:
     return _TLM_DEFAULT_CONTEXT_LIMIT
 
 
-def get_default_max_token() -> int:
+def get_default_max_tokens() -> int:
     """
     Get the default maximum output tokens allowed.
 

--- a/src/cleanlab_tlm/utils/config.py
+++ b/src/cleanlab_tlm/utils/config.py
@@ -1,6 +1,8 @@
 from cleanlab_tlm.internal.constants import (
     _TLM_DEFAULT_MODEL,
     _DEFAULT_TLM_QUALITY_PRESET,
+    _TLM_DEFAULT_CONTEXT_LIMIT,
+    _TLM_MAX_TOKEN_RANGE
 )
 
 def get_default_model() -> str:
@@ -20,3 +22,22 @@ def get_default_quality_preset() -> str:
         str: The default quality preset for TLM.
     """
     return _DEFAULT_TLM_QUALITY_PRESET
+
+def get_default_context_limit() -> int:
+    """
+    Get the default context limit for TLM.
+
+    Returns:
+        int: The default context limit for TLM.
+    """
+    return _TLM_DEFAULT_CONTEXT_LIMIT
+
+
+def get_default_max_token() -> int:
+    """
+    Get the default maximum output tokens allowed.
+
+    Returns:
+        int: The default maximum output tokens.
+    """
+    return _TLM_MAX_TOKEN_RANGE["default"][1]

--- a/src/cleanlab_tlm/utils/config.py
+++ b/src/cleanlab_tlm/utils/config.py
@@ -7,7 +7,7 @@ from cleanlab_tlm.internal.constants import (
 
 def get_default_model() -> str:
     """
-    Get the default model name for TLM.
+    Get the default based model used in TLM.
 
     Returns:
         str: The default model name for TLM.
@@ -16,7 +16,7 @@ def get_default_model() -> str:
 
 def get_default_quality_preset() -> str:
     """
-    Get the default quality preset for TLM.
+    Get the default quality preset used in TLM.
 
     Returns:
         str: The default quality preset for TLM.
@@ -35,7 +35,7 @@ def get_default_context_limit() -> int:
 
 def get_default_max_tokens() -> int:
     """
-    Get the default maximum output tokens allowed.
+    Get the default maximum output tokens value for TLM.
 
     Returns:
         int: The default maximum output tokens.


### PR DESCRIPTION
## Key info

TLM's integrations with frameworks (like LLamaIndex / Langchain) requires us to expose some important attributes, like the base model, quality present, max_output_tokens, etc.

As we use defaults for each of these, which the user can configure using the `options` argument, its useful to expose the defaults rather than hardcoding them in these integrations. 

Not exposing the defaults might result in higher maintenance (of the integration) efforts and restrict forward compatibility with TLM.

## What changed?

Create new utility to get default - TLM base model, and quality present.

## What do you want the reviewer(s) to focus on?

The new file: [src/cleanlab_tlm/utils/config.py](src/cleanlab_tlm/utils/config.py)

---

### Checklist

- [ ] _Did you link the GitHub issue?_ 
No issue raised as this functionality was discussed with Jonas on Slack.

- [ ] _Did you follow deployment steps or bump the version if needed?_
Followed [development.md](DEVELOPMENT.md).

- [ ] _Did you add/update tests?_
No.

- [ ] _What QA did you do?_
  - Install `cleanlab_tlm` from my branch and execute the methods
  
![Screenshot 2025-04-24 at 14 55 44](https://github.com/user-attachments/assets/8e4cce6c-3b36-40b5-bf19-930b878d95b5)
