### PR TITLE
fix: update TLMOptions link reused by cleanlab-codex to absolute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,7 +166,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Release of the Cleanlab TLM Python client.
 
-[Unreleased]: https://github.com/cleanlab/cleanlab-tlm/compare/v1.1.4...HEAD
+[Unreleased]: https://github.com/cleanlab/cleanlab-tlm/compare/v1.1.5...HEAD
+[1.1.5]: https://github.com/cleanlab/cleanlab-tlm/compare/v1.1.4...v1.1.5
 [1.1.4]: https://github.com/cleanlab/cleanlab-tlm/compare/v1.1.3...v1.1.4
 [1.1.3]: https://github.com/cleanlab/cleanlab-tlm/compare/v1.1.2...v1.1.3
 [1.1.2]: https://github.com/cleanlab/cleanlab-tlm/compare/v1.1.1...v1.1.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.5] - 2025-06-03
+
+- Update link in docstring
+
 ## [1.1.4] - 2025-05-30
 
 ### Changed
@@ -32,25 +36,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Improved validation + error messages for TLM's `custom_eval_criteria`. 
+- Improved validation + error messages for TLM's `custom_eval_criteria`.
 - Changed TLMOptions text in docs to have link to TLMOptions class
 
 ## [1.1.0] - 2025-04-21
 
-### Changed 
+### Changed
 
 - All `.prompt()` / `.get_trustworthiness_score()` / `.generate()` / `.score()` methods will now catch any errors and return `null` values alongside a log of why the exception occurred
 - `try_` methods are deprecated and will share the same functionality as the "non-try" methods
 
 ## [1.0.22] - 2025-04-18
 
-### Added 
+### Added
 
 - Update `response_helpfulness` default criteria
 
 ## [1.0.21] - 2025-04-17
 
-### Added 
+### Added
 
 - Add new OpenAI models: `gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano`, `o3`, `o4-mini`
 

--- a/src/cleanlab_tlm/__about__.py
+++ b/src/cleanlab_tlm/__about__.py
@@ -1,2 +1,2 @@
 # SPDX-License-Identifier: MIT
-__version__ = "1.1.4"
+__version__ = "1.1.5"

--- a/src/cleanlab_tlm/tlm.py
+++ b/src/cleanlab_tlm/tlm.py
@@ -79,7 +79,7 @@ class TLM(BaseTLM):
             - "classification": for classification tasks, where the response is a categorical prediction. \
                 When using this task type, `constrain_outputs` must be provided in the `prompt()` and `get_trustworthiness_score()` methods.
             - "code_generation": for code generation tasks.
-            - For Retrieval-Augmented Generation (RAG) tasks: try using [TrustworthyRAG](/tlm/use-cases/tlm_rag) instead of a TLM object (TrustworthyRAG has trust scoring configurations optimized for RAG).
+            - For Retrieval-Augmented Generation (RAG) tasks: try using [TrustworthyRAG](/tlm/use-cases/tlm_rag) instead of a TLM object (TrustworthyRAG has trust scoring configurations optimized for RAG).
 
         options ([TLMOptions](#class-tlmoptions), optional): a typed dict of configurations you can optionally specify.
         Available options (keys in this dict) include "model", "max_tokens",

--- a/src/cleanlab_tlm/utils/rag.py
+++ b/src/cleanlab_tlm/utils/rag.py
@@ -710,7 +710,7 @@ class EvalMetric(TypedDict):
         score (float, optional): score between 0-1 corresponding to the evaluation metric.
         A higher score indicates a higher rating for the specific evaluation criteria being measured.
 
-        log (dict, optional): additional logs and metadata, reported only if the `log` key was specified in [TLMOptions](../tlm/#class-tlmoptions).
+        log (dict, optional): additional logs and metadata, reported only if the `log` key was specified in [TLMOptions](/tlm/api/python/tlm/#class-tlmoptions).
     """
 
     score: Optional[float]


### PR DESCRIPTION
## What changed?
In the `cleanlab-codex` library, we reuse the docstring from `EvalMetric` (see [code](https://github.com/cleanlab/cleanlab-codex/blob/main/src/cleanlab_codex/types/validator.py#L9)). Since `EvalMetric` is using a relative filepath link for `TLMOptions`, the link is broken in the Codex API reference. This PR updates the link to an absolute filepath link instead.

## What do you want the reviewer(s) to focus on?

---

### Checklist

- [ ] _Did you link the GitHub issue?_
- [ ] _Did you follow deployment steps or bump the version if needed?_
- [ ] _Did you add/update tests?_
- [x] _What QA did you do?_
  - Tested docs site locally.
