### PR TITLE
get_trustworthiness_score should return 0 when response is empty

### DIFF
--- a/src/cleanlab_tlm/tlm.py
+++ b/src/cleanlab_tlm/tlm.py
@@ -512,6 +512,9 @@ class TLM(BaseTLM):
         Returns:
             [TLMScore](#class-tlmscore) objects with error messages and retryability information in place of the trustworthiness score
         """
+        if not response["response"].strip():
+            return {"trustworthiness_score": 0.0}
+
         response_json = await asyncio.wait_for(
             api.tlm_get_confidence_score(
                 self._api_key,

--- a/src/cleanlab_tlm/utils/chat.py
+++ b/src/cleanlab_tlm/utils/chat.py
@@ -86,7 +86,7 @@ def _uses_responses_api(
         tools (Optional[List[Dict[str, Any]]]): The list of tools made available for the LLM.
         use_responses (Optional[bool]): If provided, explicitly specifies whether to use responses API format.
             Cannot be set to False when responses API specific parameters are provided.
-        **responses_api_params: Responses API specific parameters. Currently supported:
+        **responses_api_kwargs: Optional keyword arguments for OpenAI's Responses API. Currently supported:
             - instructions (str): Developer instructions to prepend to the prompt with highest priority.
 
     Returns:

--- a/src/cleanlab_tlm/utils/chat.py
+++ b/src/cleanlab_tlm/utils/chat.py
@@ -73,7 +73,7 @@ def _format_tools_prompt(tools: list[dict[str, Any]], is_responses: bool = False
 
 
 def _uses_responses_api(
-    messages: list[dict[str, Any]], 
+    messages: list[dict[str, Any]],
     tools: Optional[list[dict[str, Any]]] = None,
     use_responses: Optional[bool] = None,
     **responses_api_params: Any,
@@ -97,7 +97,9 @@ def _uses_responses_api(
     """
     # First check if explicitly set to False while having responses API params
     if use_responses is False and responses_api_params:
-        raise ValueError("Responses API specific parameters are only supported in responses API format. Cannot use with use_responses=False.")
+        raise ValueError(
+            "Responses API specific parameters are only supported in responses API format. Cannot use with use_responses=False."
+        )
 
     # If explicitly set to True or False, respect that (after validation above)
     if use_responses is not None:
@@ -120,7 +122,7 @@ def _uses_responses_api(
 
 
 def _form_prompt_responses_api(
-    messages: list[dict[str, Any]], 
+    messages: list[dict[str, Any]],
     tools: Optional[list[dict[str, Any]]] = None,
     **responses_api_params: Any,
 ) -> str:
@@ -141,13 +143,13 @@ def _form_prompt_responses_api(
     output = ""
     if "instructions" in responses_api_params:
         output = f"Developer instruction (prioritize ahead of other roles): {responses_api_params['instructions']}\n\n"
-    
+
     if tools is not None:
         output += _format_tools_prompt(tools, is_responses=True) + "\n\n"
 
     # Only return content directly if there's a single user message AND no prepended content
     if len(messages) == 1 and messages[0].get("role") == "user" and not output:
-        return messages[0]["content"]
+        return str(messages[0]["content"])
 
     # Warn if the last message is a tool call
     if messages and messages[-1].get("type") == "function_call":

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -3,11 +3,13 @@ from cleanlab_tlm.internal.constants import _VALID_TLM_MODELS
 # Test TLM
 TEST_PROMPT: str = "What is the capital of France?"
 TEST_RESPONSE: str = "Paris"
+TEST_EMPTY_RESPONSE: str = ""
 TEST_PROMPT_BATCH: list[str] = [
     "What is the capital of France?",
     "What is the capital of Ukraine?",
 ]
 TEST_RESPONSE_BATCH: list[str] = ["Paris", "Kyiv"]
+TEST_EMPTY_RESPONSE_BATCH: list[str] = ["", "Kyiv"]
 TEST_CONSTRAIN_OUTPUTS_BINARY = ["Paris", "Kyiv"]
 TEST_CONSTRAIN_OUTPUTS = ["Paris", "Kyiv", "London", "New York"]
 

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -647,11 +647,7 @@ def test_form_prompt_string_with_instructions_responses() -> None:
     messages = [
         {"role": "user", "content": "What can you do?"},
     ]
-    expected = (
-        "Developer instruction (prioritize ahead of other roles): Always be concise and direct in your responses.\n\n"
-        "User: What can you do?\n\n"
-        "Assistant:"
-    )
+    expected = "System: Always be concise and direct in your responses.\n\n" "User: What can you do?\n\n" "Assistant:"
     assert form_prompt_string(messages, instructions="Always be concise and direct in your responses.") == expected
 
 
@@ -674,7 +670,7 @@ def test_form_prompt_string_with_instructions_and_tools_responses() -> None:
         }
     ]
     expected = (
-        "Developer instruction (prioritize ahead of other roles): Always be concise and direct in your responses.\n\n"
+        "System: Always be concise and direct in your responses.\n\n"
         "System: You are a function calling AI model. You are provided with function signatures within <tools> </tools> XML tags. "
         "You may call one or more functions to assist with the user query. If available tools are not relevant in assisting "
         "with user query, just respond in natural conversational language. Don't make assumptions about what values to plug "
@@ -719,7 +715,7 @@ def test_form_prompt_string_with_instructions_and_tool_calls_responses() -> None
         },
     ]
     expected = (
-        "Developer instruction (prioritize ahead of other roles): Always be concise and direct in your responses.\n\n"
+        "System: Always be concise and direct in your responses.\n\n"
         "User: What's the weather in Paris?\n\n"
         "Assistant: <tool_call>\n"
         "{\n"
@@ -749,8 +745,28 @@ def test_form_prompt_string_with_instructions_chat_completions_throws_error() ->
     ]
     with pytest.raises(
         ValueError,
-        match="Responses API specific parameters are only supported in responses API format. Cannot use with use_responses=False.",
+        match="Responses API kwargs are only supported in responses API format. Cannot use with use_responses=False.",
     ):
         form_prompt_string(
             messages, instructions="Always be concise and direct in your responses.", use_responses=False
         )
+
+
+def test_form_prompt_string_with_developer_role_begin() -> None:
+    """Test formatting with developer role in the beginning of the messages list."""
+    messages = [
+        {"role": "developer", "content": "Always be concise and direct in your responses."},
+        {"role": "user", "content": "What can you do?"},
+    ]
+    expected = "System: Always be concise and direct in your responses.\n\n" "User: What can you do?\n\n" "Assistant:"
+    assert form_prompt_string(messages) == expected
+
+
+def test_form_prompt_string_with_developer_role_middle() -> None:
+    """Test formatting with developer role in the middle of the messages list."""
+    messages = [
+        {"role": "user", "content": "What can you do?"},
+        {"role": "developer", "content": "Always be concise and direct in your responses."},
+    ]
+    expected = "User: What can you do?\n\n" "System: Always be concise and direct in your responses.\n\n" "Assistant:"
+    assert form_prompt_string(messages) == expected

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -696,7 +696,10 @@ def test_form_prompt_string_with_instructions_and_tools_responses() -> None:
         "User: What can you do?\n\n"
         "Assistant:"
     )
-    assert form_prompt_string(messages, tools=tools, instructions="Always be concise and direct in your responses.") == expected
+    assert (
+        form_prompt_string(messages, tools=tools, instructions="Always be concise and direct in your responses.")
+        == expected
+    )
 
 
 def test_form_prompt_string_with_instructions_and_tool_calls_responses() -> None:
@@ -748,4 +751,6 @@ def test_form_prompt_string_with_instructions_chat_completions_throws_error() ->
         ValueError,
         match="Responses API specific parameters are only supported in responses API format. Cannot use with use_responses=False.",
     ):
-        form_prompt_string(messages, instructions="Always be concise and direct in your responses.", use_responses=False)
+        form_prompt_string(
+            messages, instructions="Always be concise and direct in your responses.", use_responses=False
+        )


### PR DESCRIPTION
Key snippet:

```python

async def _get_trustworthiness_score_async(
    self,
    prompt: str,
    response: dict[str, Any],
    client_session: Optional[aiohttp.ClientSession] = None,
    timeout: Optional[float] = None,
    capture_exceptions: bool = False,  # noqa: ARG002
    batch_index: Optional[int] = None,
) -> TLMScore:
    """Private asynchronous method to get trustworthiness score for prompt-response pairs.

    Args:
        prompt: prompt for the TLM to evaluate
        response: response corresponding to the input prompt
        client_session: async HTTP session to use for TLM query. Defaults to None.
        timeout: timeout (in seconds) to run the prompt, defaults to None (no timeout)
        capture_exceptions (bool): if True, the returned [TLMScore](#class-tlmscore) object will include error details and retry information if any errors or timeouts occur during processing.
        batch_index: index of the prompt in the batch, used for error messages
    Returns:
        [TLMScore](#class-tlmscore) objects with error messages and retryability information in place of the trustworthiness score
    """
    if not response["response"].strip():
        return {"trustworthiness_score": 0.0}

```