### PR TITLE
get_trustworthiness_score should return 0 when response is empty

### DIFF
--- a/src/cleanlab_tlm/tlm.py
+++ b/src/cleanlab_tlm/tlm.py
@@ -512,6 +512,9 @@ class TLM(BaseTLM):
         Returns:
             [TLMScore](#class-tlmscore) objects with error messages and retryability information in place of the trustworthiness score
         """
+        if not response["response"].strip():
+            return {"trustworthiness_score": 0.0}
+
         response_json = await asyncio.wait_for(
             api.tlm_get_confidence_score(
                 self._api_key,

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -3,11 +3,13 @@ from cleanlab_tlm.internal.constants import _VALID_TLM_MODELS
 # Test TLM
 TEST_PROMPT: str = "What is the capital of France?"
 TEST_RESPONSE: str = "Paris"
+TEST_EMPTY_RESPONSE: str = ""
 TEST_PROMPT_BATCH: list[str] = [
     "What is the capital of France?",
     "What is the capital of Ukraine?",
 ]
 TEST_RESPONSE_BATCH: list[str] = ["Paris", "Kyiv"]
+TEST_EMPTY_RESPONSE_BATCH: list[str] = ["", "Kyiv"]
 TEST_CONSTRAIN_OUTPUTS_BINARY = ["Paris", "Kyiv"]
 TEST_CONSTRAIN_OUTPUTS = ["Paris", "Kyiv", "London", "New York"]
 


### PR DESCRIPTION
Key Snippet:

```python

async def _get_trustworthiness_score_async(
    self,
    prompt: str,
    response: dict[str, Any],
    client_session: Optional[aiohttp.ClientSession] = None,
    timeout: Optional[float] = None,
    capture_exceptions: bool = False,  # noqa: ARG002
    batch_index: Optional[int] = None,
) -> TLMScore:
    """Private asynchronous method to get trustworthiness score for prompt-response pairs.

    Args:
        prompt: prompt for the TLM to evaluate
        response: response corresponding to the input prompt
        client_session: async HTTP session to use for TLM query. Defaults to None.
        timeout: timeout (in seconds) to run the prompt, defaults to None (no timeout)
        capture_exceptions (bool): if True, the returned [TLMScore](#class-tlmscore) object will include error details and retry information if any errors or timeouts occur during processing.
        batch_index: index of the prompt in the batch, used for error messages
    Returns:
        [TLMScore](#class-tlmscore) objects with error messages and retryability information in place of the trustworthiness score
    """
    if not response["response"].strip():
        return {"trustworthiness_score": 0.0}

```

Add tests for both single and batch.