### PR TITLE
Update form_prompt_string to operate on a copy of input messages 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated `form_prompt_string` to operate on a copy of input messages
+
 ## [1.1.8] - 2025-06-11
 
 ### Added

--- a/src/cleanlab_tlm/utils/chat.py
+++ b/src/cleanlab_tlm/utils/chat.py
@@ -390,6 +390,7 @@ def form_prompt_string(
         ValueError: If Responses API kwargs are provided with use_responses=False.
     """
     is_responses = _uses_responses_api(messages, tools, use_responses, **responses_api_kwargs)
+    messages = messages.copy()
     return (
         _form_prompt_responses_api(messages, tools, **responses_api_kwargs)
         if is_responses

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -865,15 +865,12 @@ def test_form_prompt_string_with_instructions_developer_role_and_tools() -> None
     assert form_prompt_string(messages, tools=tools, instructions="This system prompt appears first.") == expected
 
 
-
-
 @pytest.mark.parametrize("use_tools", [False, True])
 @pytest.mark.filterwarnings("ignore:The last message is a tool call or assistant message")
 def test_form_prompt_string_does_not_change_message_length(use_tools):
-    
     messages = [
-        {"role": "system",    "content": "You are a helpful assistant."},
-        {"role": "user",      "content": "What is the capital of France?"},
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "What is the capital of France?"},
         {"role": "assistant", "content": "Paris"},
     ]
     tools = [
@@ -882,12 +879,7 @@ def test_form_prompt_string_does_not_change_message_length(use_tools):
             "function": {
                 "name": "get_capital",
                 "description": "Get the capital of a country",
-                "parameters": {
-                    "type": "object",
-                    "properties": {
-                        "country": {"type": "string"}
-                    }
-                },
+                "parameters": {"type": "object", "properties": {"country": {"type": "string"}}},
             },
         },
     ]
@@ -895,6 +887,5 @@ def test_form_prompt_string_does_not_change_message_length(use_tools):
     original_len = len(messages)
     form_prompt_string(messages=messages, tools=tools if use_tools else None)
     assert len(messages) == original_len, (
-        f"form_prompt_string mutated messages: "
-        f"expected length {original_len}, got {len(messages)}"
+        f"form_prompt_string mutated messages: " f"expected length {original_len}, got {len(messages)}"
     )

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -867,7 +867,7 @@ def test_form_prompt_string_with_instructions_developer_role_and_tools() -> None
 
 @pytest.mark.parametrize("use_tools", [False, True])
 @pytest.mark.filterwarnings("ignore:The last message is a tool call or assistant message")
-def test_form_prompt_string_does_not_change_message_length(use_tools: bool) -> None:
+def test_form_prompt_string_does_not_mutate_messages(use_tools: bool) -> None:
     messages = [
         {"role": "system", "content": "You are a helpful assistant."},
         {"role": "user", "content": "What is the capital of France?"},
@@ -884,8 +884,19 @@ def test_form_prompt_string_does_not_change_message_length(use_tools: bool) -> N
         },
     ]
 
+    original_messages = [dict(msg) for msg in messages]
     original_len = len(messages)
+
     form_prompt_string(messages=messages, tools=tools if use_tools else None)
+    
+    # Verify length hasn't changed
     assert len(messages) == original_len, (
         f"form_prompt_string mutated messages: " f"expected length {original_len}, got {len(messages)}"
     )
+
+    # Verify message contents haven't changed
+    for original, current in zip(original_messages, messages):
+        assert current == original, (
+            f"form_prompt_string mutated message content: "
+            f"expected {original}, got {current}"
+        )

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -888,7 +888,7 @@ def test_form_prompt_string_does_not_mutate_messages(use_tools: bool) -> None:
     original_len = len(messages)
 
     form_prompt_string(messages=messages, tools=tools if use_tools else None)
-    
+
     # Verify length hasn't changed
     assert len(messages) == original_len, (
         f"form_prompt_string mutated messages: " f"expected length {original_len}, got {len(messages)}"
@@ -897,6 +897,5 @@ def test_form_prompt_string_does_not_mutate_messages(use_tools: bool) -> None:
     # Verify message contents haven't changed
     for original, current in zip(original_messages, messages):
         assert current == original, (
-            f"form_prompt_string mutated message content: "
-            f"expected {original}, got {current}"
+            f"form_prompt_string mutated message content: " f"expected {original}, got {current}"
         )

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -867,7 +867,7 @@ def test_form_prompt_string_with_instructions_developer_role_and_tools() -> None
 
 @pytest.mark.parametrize("use_tools", [False, True])
 @pytest.mark.filterwarnings("ignore:The last message is a tool call or assistant message")
-def test_form_prompt_string_does_not_change_message_length(use_tools):
+def test_form_prompt_string_does_not_change_message_length(use_tools: bool) -> None:
     messages = [
         {"role": "system", "content": "You are a helpful assistant."},
         {"role": "user", "content": "What is the capital of France?"},

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -863,3 +863,38 @@ def test_form_prompt_string_with_instructions_developer_role_and_tools() -> None
         "Assistant:"
     )
     assert form_prompt_string(messages, tools=tools, instructions="This system prompt appears first.") == expected
+
+
+
+
+@pytest.mark.parametrize("use_tools", [False, True])
+@pytest.mark.filterwarnings("ignore:The last message is a tool call or assistant message")
+def test_form_prompt_string_does_not_change_message_length(use_tools):
+    
+    messages = [
+        {"role": "system",    "content": "You are a helpful assistant."},
+        {"role": "user",      "content": "What is the capital of France?"},
+        {"role": "assistant", "content": "Paris"},
+    ]
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_capital",
+                "description": "Get the capital of a country",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "country": {"type": "string"}
+                    }
+                },
+            },
+        },
+    ]
+
+    original_len = len(messages)
+    form_prompt_string(messages=messages, tools=tools if use_tools else None)
+    assert len(messages) == original_len, (
+        f"form_prompt_string mutated messages: "
+        f"expected length {original_len}, got {len(messages)}"
+    )


### PR DESCRIPTION
Also, add a corresponding test to ensure the input messages remain unchanged.