### PR TITLE
Enforce typing for messages in `chat.py`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ extra-dependencies = [
   "pytest-asyncio",
   "python-dotenv",
   "tiktoken",
+  "openai"
 ]
 [tool.hatch.envs.types.scripts]
 check = "mypy --strict --install-types --non-interactive {args:src/cleanlab_tlm tests}"

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -610,7 +610,6 @@ def test_form_prompt_string_assistant_content_before_tool_calls_responses() -> N
             "name": "search_knowledge_base",
             "arguments": '{"query": "ACME warranty policy terms and conditions"}',
             "call_id": "call_123",
-            "content": "I'll help you find information about our warranty policy. Let me search our knowledge base for the details.",
         },
         {
             "type": "function_call_output",
@@ -620,8 +619,7 @@ def test_form_prompt_string_assistant_content_before_tool_calls_responses() -> N
     ]
     expected = (
         "User: Can you help me find information about ACME's warranty policy?\n\n"
-        "Assistant: I'll help you find information about our warranty policy. Let me search our knowledge base for the details.\n\n"
-        "<tool_call>\n"
+        "Assistant: <tool_call>\n"
         "{\n"
         '  "name": "search_knowledge_base",\n'
         '  "arguments": {\n'


### PR DESCRIPTION
No change to high-level function's signature:
```python

def form_prompt_string(
    messages: list[dict[str, Any]],
    tools: Optional[list[dict[str, Any]]] = None,
    use_responses: Optional[bool] = None,
    **responses_api_kwargs: Any,
) -> str:

```

Endpoint-specific functions now enforcing typing of messages
```python

def _form_prompt_chat_completions_api(
    messages: list[ChatCompletionMessageParam], tools: Optional[list[dict[str, Any]]] = None
) -> str:

```

```python

def _form_prompt_responses_api(
    messages: list[ResponseInputItemParam],
    tools: Optional[list[dict[str, Any]]] = None,
    **responses_api_kwargs: Any,
) -> str:

```