### PR TITLE
bug fix for system prompt after user message

### DIFF
--- a/src/cleanlab_tlm/utils/chat.py
+++ b/src/cleanlab_tlm/utils/chat.py
@@ -183,6 +183,28 @@ def _get_prefix(msg: dict[str, Any], prev_msg_role: Optional[str] = None) -> str
     return role.capitalize() + ": "
 
 
+def _find_index_after_first_system_block(messages: list[dict[str, Any]]) -> int:
+    """
+    Find the index after the first consecutive block of system messages.
+
+    Args:
+        messages (List[Dict]): A list of message dictionaries.
+
+    Returns:
+        int: The index after the first consecutive block of system messages.
+             Returns -1 if no system messages are found.
+    """
+    last_system_idx = -1
+    for i, msg in enumerate(messages):
+        if msg.get("role") in _SYSTEM_ROLES:
+            last_system_idx = i
+        else:
+            # Found a non-system message, so we've reached the end of the first system block
+            break
+
+    return last_system_idx
+
+
 def _form_prompt_responses_api(
     messages: list[dict[str, Any]],
     tools: Optional[list[dict[str, Any]]] = None,
@@ -205,11 +227,8 @@ def _form_prompt_responses_api(
     messages = messages.copy()
     output = ""
 
-    # Find the index after the last system message
-    last_system_idx = -1
-    for i, msg in enumerate(messages):
-        if msg.get("role") in _SYSTEM_ROLES:
-            last_system_idx = i
+    # Find the index after the first consecutive block of system messages
+    last_system_idx = _find_index_after_first_system_block(messages)
 
     # Insert tool definitions and instructions after system messages if needed
     if tools is not None:
@@ -297,11 +316,8 @@ def _form_prompt_chat_completions_api(
     messages = messages.copy()
     output = ""
 
-    # Find the index after the last system message
-    last_system_idx = -1
-    for i, msg in enumerate(messages):
-        if msg.get("role") in _SYSTEM_ROLES:
-            last_system_idx = i
+    # Find the index after the first consecutive block of system messages
+    last_system_idx = _find_index_after_first_system_block(cast(list[dict[str, Any]], messages))
 
     if tools is not None:
         messages.insert(

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -978,3 +978,119 @@ def test_form_prompt_responses_api_does_not_mutate_messages(use_tools: bool) -> 
         assert current == original, (
             f"_form_prompt_responses_api mutated message content: " f"expected {original}, got {current}"
         )
+
+
+def test_form_prompt_string_with_tools_after_first_system_block_chat_completions() -> None:
+    """Test that tools are inserted after the first consecutive block of system messages."""
+    messages = [
+        {"role": "system", "content": "First system message."},
+        {"role": "system", "content": "Second system message."},
+        {"role": "user", "content": "What can you do?"},
+        {"role": "assistant", "content": "I can help you."},
+        {"role": "system", "content": "Third system message later."},
+        {"role": "user", "content": "Tell me more."},
+    ]
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "search",
+                "description": "Search the web for information",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string", "description": "The search query"}},
+                    "required": ["query"],
+                },
+            },
+        }
+    ]
+
+    result = form_prompt_string(messages, tools)
+
+    expected = (
+        "System: First system message.\n\n"
+        "Second system message.\n\n"
+        "You are a function calling AI model. You are provided with function signatures within <tools> </tools> XML tags. "
+        "You may call one or more functions to assist with the user query. If available tools are not relevant in assisting "
+        "with user query, just respond in natural conversational language. Don't make assumptions about what values to plug "
+        "into functions. After calling & executing the functions, you will be provided with function results within "
+        "<tool_response> </tool_response> XML tags.\n\n"
+        "<tools>\n"
+        '{"type":"function","function":{"name":"search","description":"Search the web for information","parameters":'
+        '{"type":"object","properties":{"query":{"type":"string","description":"The search query"}},"required":["query"]}}}\n'
+        "</tools>\n\n"
+        "For each function call return a JSON object, with the following pydantic model json schema:\n"
+        "{'name': <function-name>, 'arguments': <args-dict>}\n"
+        "Each function call should be enclosed within <tool_call> </tool_call> XML tags.\n"
+        "Example:\n"
+        "<tool_call>\n"
+        "{'name': <function-name>, 'arguments': <args-dict>}\n"
+        "</tool_call>\n\n"
+        "Note: Your past messages will include a call_id in the <tool_call> XML tags. "
+        "However, do not generate your own call_id when making a function call.\n\n"
+        "User: What can you do?\n\n"
+        "Assistant: I can help you.\n\n"
+        "System: Third system message later.\n\n"
+        "User: Tell me more.\n\n"
+        "Assistant:"
+    )
+
+    assert result == expected
+
+
+def test_form_prompt_string_with_tools_after_first_system_block_responses() -> None:
+    """Test that tools are inserted after the first consecutive block of system messages in responses format."""
+    messages = [
+        {"role": "system", "content": "First system message."},
+        {"role": "system", "content": "Second system message."},
+        {"role": "user", "content": "What can you do?"},
+        {"role": "assistant", "content": "I can help you."},
+        {"role": "system", "content": "Third system message later."},
+        {"role": "user", "content": "Tell me more."},
+    ]
+    tools = [
+        {
+            "type": "function",
+            "name": "search",
+            "description": "Search the web for information",
+            "parameters": {
+                "type": "object",
+                "properties": {"query": {"type": "string", "description": "The search query"}},
+                "required": ["query"],
+            },
+            "strict": True,
+        }
+    ]
+
+    result = form_prompt_string(messages, tools)
+
+    expected = (
+        "System: First system message.\n\n"
+        "Second system message.\n\n"
+        "You are a function calling AI model. You are provided with function signatures within <tools> </tools> XML tags. "
+        "You may call one or more functions to assist with the user query. If available tools are not relevant in assisting "
+        "with user query, just respond in natural conversational language. Don't make assumptions about what values to plug "
+        "into functions. After calling & executing the functions, you will be provided with function results within "
+        "<tool_response> </tool_response> XML tags.\n\n"
+        "<tools>\n"
+        '{"type":"function","name":"search","description":"Search the web for information","parameters":'
+        '{"type":"object","properties":{"query":{"type":"string","description":"The search query"}},"required":["query"]},'
+        '"strict":true}\n'
+        "</tools>\n\n"
+        "For each function call return a JSON object, with the following pydantic model json schema:\n"
+        "{'name': <function-name>, 'arguments': <args-dict>}\n"
+        "Each function call should be enclosed within <tool_call> </tool_call> XML tags.\n"
+        "Example:\n"
+        "<tool_call>\n"
+        "{'name': <function-name>, 'arguments': <args-dict>}\n"
+        "</tool_call>\n\n"
+        "Note: Your past messages will include a call_id in the <tool_call> XML tags. "
+        "However, do not generate your own call_id when making a function call.\n\n"
+        "User: What can you do?\n\n"
+        "Assistant: I can help you.\n\n"
+        "System: Third system message later.\n\n"
+        "User: Tell me more.\n\n"
+        "Assistant:"
+    )
+
+    assert result == expected


### PR DESCRIPTION
Added bug fixes for two new test cases in which a system message can appear after the user/assistant exchange—for example, in our upcoming LangGraph, where we insert system messages for the assistant to revise its reply. Previously, the tools prompt was being appended after the rewrite system message.

```python
def test_form_prompt_string_with_tools_after_first_system_block_chat_completions() -> None:
    """Test that tools are inserted after the first consecutive block of system messages."""
    messages = [
        {"role": "system", "content": "First system message."},
        {"role": "system", "content": "Second system message."},
        {"role": "user", "content": "What can you do?"},
        {"role": "assistant", "content": "I can help you."},
        {"role": "system", "content": "Third system message later."},
        {"role": "user", "content": "Tell me more."},
    ]
    tools = [
        {
            "type": "function",
            "function": {
                "name": "search",
                "description": "Search the web for information",
                "parameters": {
                    "type": "object",
                    "properties": {"query": {"type": "string", "description": "The search query"}},
                    "required": ["query"],
                },
            },
        }
    ]

    result = form_prompt_string(messages, tools)

    expected = (
        "System: First system message.\n\n"
        "Second system message.\n\n"
        "You are a function calling AI model. You are provided with function signatures within <tools> </tools> XML tags. "
        "You may call one or more functions to assist with the user query. If available tools are not relevant in assisting "
        "with user query, just respond in natural conversational language. Don't make assumptions about what values to plug "
        "into functions. After calling & executing the functions, you will be provided with function results within "
        "<tool_response> </tool_response> XML tags.\n\n"
        "<tools>\n"
        '{"type":"function","function":{"name":"search","description":"Search the web for information","parameters":'
        '{"type":"object","properties":{"query":{"type":"string","description":"The search query"}},"required":["query"]}}}\n'
        "</tools>\n\n"
        "For each function call return a JSON object, with the following pydantic model json schema:\n"
        "{'name': <function-name>, 'arguments': <args-dict>}\n"
        "Each function call should be enclosed within <tool_call> </tool_call> XML tags.\n"
        "Example:\n"
        "<tool_call>\n"
        "{'name': <function-name>, 'arguments': <args-dict>}\n"
        "</tool_call>\n\n"
        "Note: Your past messages will include a call_id in the <tool_call> XML tags. "
        "However, do not generate your own call_id when making a function call.\n\n"
        "User: What can you do?\n\n"
        "Assistant: I can help you.\n\n"
        "System: Third system message later.\n\n"
        "User: Tell me more.\n\n"
        "Assistant:"
    )

    assert result == expected


def test_form_prompt_string_with_tools_after_first_system_block_responses() -> None:
    """Test that tools are inserted after the first consecutive block of system messages in responses format."""
    messages = [
        {"role": "system", "content": "First system message."},
        {"role": "system", "content": "Second system message."},
        {"role": "user", "content": "What can you do?"},
        {"role": "assistant", "content": "I can help you."},
        {"role": "system", "content": "Third system message later."},
        {"role": "user", "content": "Tell me more."},
    ]
    tools = [
        {
            "type": "function",
            "name": "search",
            "description": "Search the web for information",
            "parameters": {
                "type": "object",
                "properties": {"query": {"type": "string", "description": "The search query"}},
                "required": ["query"],
            },
            "strict": True,
        }
    ]

    result = form_prompt_string(messages, tools)

    expected = (
        "System: First system message.\n\n"
        "Second system message.\n\n"
        "You are a function calling AI model. You are provided with function signatures within <tools> </tools> XML tags. "
        "You may call one or more functions to assist with the user query. If available tools are not relevant in assisting "
        "with user query, just respond in natural conversational language. Don't make assumptions about what values to plug "
        "into functions. After calling & executing the functions, you will be provided with function results within "
        "<tool_response> </tool_response> XML tags.\n\n"
        "<tools>\n"
        '{"type":"function","name":"search","description":"Search the web for information","parameters":'
        '{"type":"object","properties":{"query":{"type":"string","description":"The search query"}},"required":["query"]},'
        '"strict":true}\n'
        "</tools>\n\n"
        "For each function call return a JSON object, with the following pydantic model json schema:\n"
        "{'name': <function-name>, 'arguments': <args-dict>}\n"
        "Each function call should be enclosed within <tool_call> </tool_call> XML tags.\n"
        "Example:\n"
        "<tool_call>\n"
        "{'name': <function-name>, 'arguments': <args-dict>}\n"
        "</tool_call>\n\n"
        "Note: Your past messages will include a call_id in the <tool_call> XML tags. "
        "However, do not generate your own call_id when making a function call.\n\n"
        "User: What can you do?\n\n"
        "Assistant: I can help you.\n\n"
        "System: Third system message later.\n\n"
        "User: Tell me more.\n\n"
        "Assistant:"
    )

    assert result == expected
```
