### PR TITLE
add `form_response_string_chat_completions_api` to `chat.py`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.1.10] - 2025-06-20
-
-### Added
-
-- Added `TLMChatCompletion` module, providing support for trust scoring with OpenAI ChatCompletion objects
-- Added a VPC compatible version of `TLMChatCompletion`
+## [1.1.11] - 2025-06-23
 
 ### Changed
 
@@ -20,9 +15,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Bug fix in `chat.py` for formatting system prompt after user messages
 - Bug fix in `chat.py` for empty tool list still using tools prompt
 - Bug fix in `chat.py` for handling empty strings args
+
+## [1.1.10] - 2025-06-20
+
+### Added
+
+- Added `TLMChatCompletion` module, providing support for trust scoring with OpenAI ChatCompletion objects
+- Added a VPC compatible version of `TLMChatCompletion`
+
+### Fixed
+
+- Bug fix in `chat.py` for formatting system prompt after user messages
 
 ## [1.1.9] - 2025-06-17
 
@@ -205,7 +210,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Release of the Cleanlab TLM Python client.
 
-[Unreleased]: https://github.com/cleanlab/cleanlab-tlm/compare/v1.1.10...HEAD
+[Unreleased]: https://github.com/cleanlab/cleanlab-tlm/compare/v1.1.11...HEAD
+[1.1.11]: https://github.com/cleanlab/cleanlab-tlm/compare/v1.1.10...v1.1.11
 [1.1.10]: https://github.com/cleanlab/cleanlab-tlm/compare/v1.1.9...v1.1.10
 [1.1.9]: https://github.com/cleanlab/cleanlab-tlm/compare/v1.1.8...v1.1.9
 [1.1.8]: https://github.com/cleanlab/cleanlab-tlm/compare/v1.1.7...v1.1.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.1.11] - 2025-06-23
 
+### Changed
+
+- Revised tools prompt in `chat.py`
+
 ### Fixed
 
 - Bug fix in `chat.py` for empty tool list still using tools prompt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `form_response_string_chat_completions_api` in `chat.py`
+
 
 ## [1.1.12] - 2025-06-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `TLMChatCompletion` module, providing support for trust scoring with OpenAI ChatCompletion objects
 - Added a VPC compatible version of `TLMChatCompletion`
 
+### Changed
+
+- Revised tools prompt in `chat.py`
+
 ### Fixed
 
-- Bug fix for formatting system prompt after user messages
+- Bug fix in `chat.py` for formatting system prompt after user messages
+- Bug fix in `chat.py` for empty tool list still using tools prompt
+- Bug fix in `chat.py` for handling empty strings args
 
 ## [1.1.9] - 2025-06-17
 

--- a/src/cleanlab_tlm/__about__.py
+++ b/src/cleanlab_tlm/__about__.py
@@ -1,2 +1,2 @@
 # SPDX-License-Identifier: MIT
-__version__ = "1.1.10"
+__version__ = "1.1.11"

--- a/src/cleanlab_tlm/__about__.py
+++ b/src/cleanlab_tlm/__about__.py
@@ -1,3 +1,2 @@
 # SPDX-License-Identifier: MIT
 __version__ = "1.1.12"
-

--- a/src/cleanlab_tlm/utils/chat.py
+++ b/src/cleanlab_tlm/utils/chat.py
@@ -443,7 +443,7 @@ def form_prompt_string(
     )
 
 
-def form_prompt_string_chat_completions_api(response: dict[str, Any]) -> str:
+def form_response_string_chat_completions_api(response: dict[str, Any]) -> str:
     """
     Format an assistant response message dictionary from the Chat Completions API into a single string.
 

--- a/src/cleanlab_tlm/utils/chat.py
+++ b/src/cleanlab_tlm/utils/chat.py
@@ -476,7 +476,7 @@ def form_prompt_string_chat_completions_api(response: dict[str, Any]) -> str:
     if "tool_calls" in response:
         try:
             tool_calls = "\n".join(
-                f"{_TOOL_CALL_TAG_START}\n{json.dumps({'name': call['function']['name'], 'arguments': call['function']['arguments']}, indent=2)}\n{_TOOL_CALL_TAG_END}"
+                f"{_TOOL_CALL_TAG_START}\n{json.dumps({'name': call['function']['name'], 'arguments': json.loads(call['function']['arguments']) if call['function']['arguments'] else {}}, indent=2)}\n{_TOOL_CALL_TAG_END}"
                 for call in response["tool_calls"]
             )
             return f"{content}\n{tool_calls}".strip() if content else tool_calls

--- a/src/cleanlab_tlm/utils/chat.py
+++ b/src/cleanlab_tlm/utils/chat.py
@@ -469,9 +469,7 @@ def form_prompt_string_chat_completions_api(response: dict[str, Any]) -> str:
     if not isinstance(response, dict):
         raise TypeError(f"Expected response to be a dict, got {type(response).__name__}")
 
-    content = response.get("content", "")
-    if content is None:
-        content = ""
+    content = response.get("content") or ""
 
     if "tool_calls" in response:
         try:

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1385,7 +1385,7 @@ def test_form_prompt_string_chat_completions_api_malformed_tool_calls() -> None:
         result = form_prompt_string_chat_completions_api(response)
         assert result == "I'll help you."
 
-    # Test with invalid JSON in arguments - this should now trigger a warning
+    # Test with invalid JSON in arguments - this should trigger a warning
     response = {
         "content": "Let me check that.",
         "tool_calls": [

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1239,7 +1239,9 @@ def test_form_prompt_string_chat_completions_api_just_tool_calls() -> None:
         "<tool_call>\n"
         "{\n"
         '  "name": "get_weather",\n'
-        '  "arguments": "{\\"location\\": \\"Paris\\"}"\n'
+        '  "arguments": {\n'
+        '    "location": "Paris"\n'
+        "  }\n"
         "}\n"
         "</tool_call>"
     )
@@ -1265,7 +1267,9 @@ def test_form_prompt_string_chat_completions_api_content_and_tool_calls() -> Non
         "<tool_call>\n"
         "{\n"
         '  "name": "get_weather",\n'
-        '  "arguments": "{\\"location\\": \\"Paris\\"}"\n'
+        '  "arguments": {\n'
+        '    "location": "Paris"\n'
+        "  }\n"
         "}\n"
         "</tool_call>"
     )
@@ -1297,13 +1301,17 @@ def test_form_prompt_string_chat_completions_api_multiple_tool_calls() -> None:
         "<tool_call>\n"
         "{\n"
         '  "name": "get_weather",\n'
-        '  "arguments": "{\\"location\\": \\"Paris\\"}"\n'
+        '  "arguments": {\n'
+        '    "location": "Paris"\n'
+        "  }\n"
         "}\n"
         "</tool_call>\n"
         "<tool_call>\n"
         "{\n"
         '  "name": "get_time",\n'
-        '  "arguments": "{\\"timezone\\": \\"UTC\\"}"\n'
+        '  "arguments": {\n'
+        '    "timezone": "UTC"\n'
+        "  }\n"
         "}\n"
         "</tool_call>"
     )
@@ -1345,7 +1353,7 @@ def test_form_prompt_string_chat_completions_api_empty_arguments() -> None:
         "<tool_call>\n"
         "{\n"
         '  "name": "execute_action",\n'
-        '  "arguments": ""\n'
+        '  "arguments": {}\n'
         "}\n"
         "</tool_call>"
     )
@@ -1377,8 +1385,7 @@ def test_form_prompt_string_chat_completions_api_malformed_tool_calls() -> None:
         result = form_prompt_string_chat_completions_api(response)
         assert result == "I'll help you."
 
-    # Test with invalid JSON in arguments - this doesn't trigger a warning since
-    # the function just passes the arguments string as-is
+    # Test with invalid JSON in arguments - this should now trigger a warning
     response = {
         "content": "Let me check that.",
         "tool_calls": [
@@ -1391,15 +1398,7 @@ def test_form_prompt_string_chat_completions_api_malformed_tool_calls() -> None:
         ],
     }
 
-    # No warning expected here, function just passes the string through
-    result = form_prompt_string_chat_completions_api(response)
-    expected = (
-        "Let me check that.\n"
-        "<tool_call>\n"
-        "{\n"
-        '  "name": "get_weather",\n'
-        '  "arguments": "invalid json{"\n'
-        "}\n"
-        "</tool_call>"
-    )
-    assert result == expected
+    # Warning expected since JSON parsing will fail
+    with pytest.warns(UserWarning, match="Error formatting tool_calls in response.*Returning content only"):
+        result = form_prompt_string_chat_completions_api(response)
+        assert result == "Let me check that."

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1252,6 +1252,7 @@ def test_form_prompt_string_chat_completions_api_just_tool_calls() -> None:
 def test_form_prompt_string_chat_completions_api_content_and_tool_calls() -> None:
     """Test form_prompt_string_chat_completions_api with both content and tool calls."""
     response = {
+        "role": "assistant",
         "content": "I'll check the weather for you.",
         "tool_calls": [
             {
@@ -1280,6 +1281,7 @@ def test_form_prompt_string_chat_completions_api_content_and_tool_calls() -> Non
 def test_form_prompt_string_chat_completions_api_multiple_tool_calls() -> None:
     """Test form_prompt_string_chat_completions_api with multiple tool calls."""
     response = {
+        "role": "assistant",
         "content": "Let me check multiple things for you.",
         "tool_calls": [
             {
@@ -1338,6 +1340,7 @@ def test_form_prompt_string_chat_completions_api_missing_content() -> None:
 def test_form_prompt_string_chat_completions_api_empty_arguments() -> None:
     """Test form_prompt_string_chat_completions_api with empty arguments."""
     response = {
+        "role": "assistant",
         "content": "Running action",
         "tool_calls": [
             {
@@ -1377,6 +1380,7 @@ def test_form_prompt_string_chat_completions_api_malformed_tool_calls() -> None:
     """Test form_prompt_string_chat_completions_api handles malformed tool calls gracefully."""
     # Test with missing function key - this should trigger a warning
     response = {
+        "role": "assistant",
         "content": "I'll help you.",
         "tool_calls": [{"invalid": "structure"}],
     }

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -79,10 +79,12 @@ def test_form_prompt_string_with_tools_chat_completions() -> None:
         }
     ]
     expected = (
-        "System: You are a function calling AI model. You are provided with function signatures within <tools> </tools> XML tags. "
-        "You may call one or more functions to assist with the user query. If available tools are not relevant in assisting "
-        "with user query, just respond in natural conversational language. Don't make assumptions about what values to plug "
-        "into functions. After calling & executing the functions, you will be provided with function results within "
+        "System: You are an AI Assistant that can call provided tools (a.k.a. functions). "
+        "The set of available tools is provided to you as function signatures within "
+        "<tools> </tools> XML tags. "
+        "You may call one or more of these functions to assist with the user query. If the provided functions are not helpful/relevant, "
+        "then just respond in natural conversational language. Don't make assumptions about what values to plug "
+        "into functions. After you choose to call a function, you will be provided with the function's results within "
         "<tool_response> </tool_response> XML tags.\n\n"
         "<tools>\n"
         '{"type":"function","function":{"name":"search","description":"Search the web for information","parameters":'
@@ -131,10 +133,12 @@ def test_form_prompt_string_with_tools_responses() -> None:
         }
     ]
     expected = (
-        "System: You are a function calling AI model. You are provided with function signatures within <tools> </tools> XML tags. "
-        "You may call one or more functions to assist with the user query. If available tools are not relevant in assisting "
-        "with user query, just respond in natural conversational language. Don't make assumptions about what values to plug "
-        "into functions. After calling & executing the functions, you will be provided with function results within "
+        "System: You are an AI Assistant that can call provided tools (a.k.a. functions). "
+        "The set of available tools is provided to you as function signatures within "
+        "<tools> </tools> XML tags. "
+        "You may call one or more of these functions to assist with the user query. If the provided functions are not helpful/relevant, "
+        "then just respond in natural conversational language. Don't make assumptions about what values to plug "
+        "into functions. After you choose to call a function, you will be provided with the function's results within "
         "<tool_response> </tool_response> XML tags.\n\n"
         "<tools>\n"
         '{"type":"function","name":"fetch_user_flight_information","description":"Fetch all tickets for the user along with corresponding flight information and seat assignments.\\n\\n'
@@ -198,6 +202,7 @@ def test_form_prompt_string_with_tool_calls_chat_completions() -> None:
         '  "call_id": "call_123"\n'
         "}\n"
         "</tool_call>\n\n"
+        "Tool: "
         "<tool_response>\n"
         "{\n"
         '  "name": "get_weather",\n'
@@ -237,6 +242,7 @@ def test_form_prompt_string_with_tool_calls_responses() -> None:
         '  "call_id": "call_123"\n'
         "}\n"
         "</tool_call>\n\n"
+        "Tool: "
         "<tool_response>\n"
         "{\n"
         '  "name": "get_weather",\n'
@@ -287,6 +293,7 @@ def test_form_prompt_string_with_tool_calls_two_user_messages_chat_completions()
         '  "call_id": "call_123"\n'
         "}\n"
         "</tool_call>\n\n"
+        "Tool: "
         "<tool_response>\n"
         "{\n"
         '  "name": "get_weather",\n'
@@ -330,6 +337,7 @@ def test_form_prompt_string_with_tool_calls_two_user_messages_responses() -> Non
         '  "call_id": "call_123"\n'
         "}\n"
         "</tool_call>\n\n"
+        "Tool: "
         "<tool_response>\n"
         "{\n"
         '  "name": "get_weather",\n'
@@ -369,10 +377,12 @@ def test_form_prompt_string_with_tools_and_system_chat_completions() -> None:
     ]
     expected = (
         "System: You are ACME Support, the official AI assistant for ACME Corporation. Your role is to provide exceptional customer service and technical support. You are knowledgeable about all ACME products and services, and you maintain a warm, professional, and solution-oriented approach. You can search our knowledge base to provide accurate and up-to-date information about our products, policies, and support procedures.\n\n"
-        "You are a function calling AI model. You are provided with function signatures within <tools> </tools> XML tags. "
-        "You may call one or more functions to assist with the user query. If available tools are not relevant in assisting "
-        "with user query, just respond in natural conversational language. Don't make assumptions about what values to plug "
-        "into functions. After calling & executing the functions, you will be provided with function results within "
+        "You are an AI Assistant that can call provided tools (a.k.a. functions). "
+        "The set of available tools is provided to you as function signatures within "
+        "<tools> </tools> XML tags. "
+        "You may call one or more of these functions to assist with the user query. If the provided functions are not helpful/relevant, "
+        "then just respond in natural conversational language. Don't make assumptions about what values to plug "
+        "into functions. After you choose to call a function, you will be provided with the function's results within "
         "<tool_response> </tool_response> XML tags.\n\n"
         "<tools>\n"
         '{"type":"function","function":{"name":"search","description":"Search the web for information","parameters":'
@@ -417,10 +427,12 @@ def test_form_prompt_string_with_tools_and_system_responses() -> None:
     ]
     expected = (
         "System: You are ACME Support, the official AI assistant for ACME Corporation. Your role is to provide exceptional customer service and technical support. You are knowledgeable about all ACME products and services, and you maintain a warm, professional, and solution-oriented approach. You can search our knowledge base to provide accurate and up-to-date information about our products, policies, and support procedures.\n\n"
-        "You are a function calling AI model. You are provided with function signatures within <tools> </tools> XML tags. "
-        "You may call one or more functions to assist with the user query. If available tools are not relevant in assisting "
-        "with user query, just respond in natural conversational language. Don't make assumptions about what values to plug "
-        "into functions. After calling & executing the functions, you will be provided with function results within "
+        "You are an AI Assistant that can call provided tools (a.k.a. functions). "
+        "The set of available tools is provided to you as function signatures within "
+        "<tools> </tools> XML tags. "
+        "You may call one or more of these functions to assist with the user query. If the provided functions are not helpful/relevant, "
+        "then just respond in natural conversational language. Don't make assumptions about what values to plug "
+        "into functions. After you choose to call a function, you will be provided with the function's results within "
         "<tool_response> </tool_response> XML tags.\n\n"
         "<tools>\n"
         '{"type":"function","name":"search","description":"Search the web for information","parameters":'
@@ -531,10 +543,12 @@ def test_form_prompt_string_warns_on_tool_call_last_responses() -> None:
         }
     ]
     responses_tools_expected = (
-        "System: You are a function calling AI model. You are provided with function signatures within <tools> </tools> XML tags. "
-        "You may call one or more functions to assist with the user query. If available tools are not relevant in assisting "
-        "with user query, just respond in natural conversational language. Don't make assumptions about what values to plug "
-        "into functions. After calling & executing the functions, you will be provided with function results within "
+        "System: You are an AI Assistant that can call provided tools (a.k.a. functions). "
+        "The set of available tools is provided to you as function signatures within "
+        "<tools> </tools> XML tags. "
+        "You may call one or more of these functions to assist with the user query. If the provided functions are not helpful/relevant, "
+        "then just respond in natural conversational language. Don't make assumptions about what values to plug "
+        "into functions. After you choose to call a function, you will be provided with the function's results within "
         "<tool_response> </tool_response> XML tags.\n\n"
         "<tools>\n"
         '{"type":"function","name":"fetch_user_flight_information","description":"Fetch flight information","parameters":'
@@ -596,6 +610,7 @@ def test_form_prompt_string_assistant_content_before_tool_calls_chat_completions
         '  "call_id": "call_123"\n'
         "}\n"
         "</tool_call>\n\n"
+        "Tool: "
         "<tool_response>\n"
         "{\n"
         '  "name": "search_knowledge_base",\n'
@@ -637,6 +652,7 @@ def test_form_prompt_string_assistant_content_before_tool_calls_responses() -> N
         '  "call_id": "call_123"\n'
         "}\n"
         "</tool_call>\n\n"
+        "Tool: "
         "<tool_response>\n"
         "{\n"
         '  "name": "search_knowledge_base",\n'
@@ -678,14 +694,17 @@ def test_form_prompt_string_with_instructions_and_tools_responses() -> None:
     ]
     expected = (
         "System: Always be concise and direct in your responses.\n\n"
-        "You are a function calling AI model. You are provided with function signatures within <tools> </tools> XML tags. "
-        "You may call one or more functions to assist with the user query. If available tools are not relevant in assisting "
-        "with user query, just respond in natural conversational language. Don't make assumptions about what values to plug "
-        "into functions. After calling & executing the functions, you will be provided with function results within "
+        "You are an AI Assistant that can call provided tools (a.k.a. functions). "
+        "The set of available tools is provided to you as function signatures within "
+        "<tools> </tools> XML tags. "
+        "You may call one or more of these functions to assist with the user query. If the provided functions are not helpful/relevant, "
+        "then just respond in natural conversational language. Don't make assumptions about what values to plug "
+        "into functions. After you choose to call a function, you will be provided with the function's results within "
         "<tool_response> </tool_response> XML tags.\n\n"
         "<tools>\n"
         '{"type":"function","name":"search","description":"Search the web for information","parameters":'
-        '{"type":"object","properties":{"query":{"type":"string","description":"The search query"}},"required":["query"]},"strict":true}\n'
+        '{"type":"object","properties":{"query":{"type":"string","description":"The search query"}},"required":["query"]},'
+        '"strict":true}\n'
         "</tools>\n\n"
         "For each function call return a JSON object, with the following pydantic model json schema:\n"
         "{'name': <function-name>, 'arguments': <args-dict>}\n"
@@ -733,6 +752,7 @@ def test_form_prompt_string_with_instructions_and_tool_calls_responses() -> None
         '  "call_id": "call_123"\n'
         "}\n"
         "</tool_call>\n\n"
+        "Tool: "
         "<tool_response>\n"
         "{\n"
         '  "name": "get_weather",\n'
@@ -800,10 +820,12 @@ def test_form_prompt_string_with_developer_role_and_tools() -> None:
     ]
     expected = (
         "System: Always be concise and direct in your responses.\n\n"
-        "You are a function calling AI model. You are provided with function signatures within <tools> </tools> XML tags. "
-        "You may call one or more functions to assist with the user query. If available tools are not relevant in assisting "
-        "with user query, just respond in natural conversational language. Don't make assumptions about what values to plug "
-        "into functions. After calling & executing the functions, you will be provided with function results within "
+        "You are an AI Assistant that can call provided tools (a.k.a. functions). "
+        "The set of available tools is provided to you as function signatures within "
+        "<tools> </tools> XML tags. "
+        "You may call one or more of these functions to assist with the user query. If the provided functions are not helpful/relevant, "
+        "then just respond in natural conversational language. Don't make assumptions about what values to plug "
+        "into functions. After you choose to call a function, you will be provided with the function's results within "
         "<tool_response> </tool_response> XML tags.\n\n"
         "<tools>\n"
         '{"type":"function","name":"search","description":"Search the web for information","parameters":'
@@ -847,10 +869,12 @@ def test_form_prompt_string_with_instructions_developer_role_and_tools() -> None
     expected = (
         "System: This system prompt appears first.\n\n"
         "Always be concise and direct in your responses.\n\n"
-        "You are a function calling AI model. You are provided with function signatures within <tools> </tools> XML tags. "
-        "You may call one or more functions to assist with the user query. If available tools are not relevant in assisting "
-        "with user query, just respond in natural conversational language. Don't make assumptions about what values to plug "
-        "into functions. After calling & executing the functions, you will be provided with function results within "
+        "You are an AI Assistant that can call provided tools (a.k.a. functions). "
+        "The set of available tools is provided to you as function signatures within "
+        "<tools> </tools> XML tags. "
+        "You may call one or more of these functions to assist with the user query. If the provided functions are not helpful/relevant, "
+        "then just respond in natural conversational language. Don't make assumptions about what values to plug "
+        "into functions. After you choose to call a function, you will be provided with the function's results within "
         "<tool_response> </tool_response> XML tags.\n\n"
         "<tools>\n"
         '{"type":"function","name":"search","description":"Search the web for information","parameters":'
@@ -980,8 +1004,9 @@ def test_form_prompt_responses_api_does_not_mutate_messages(use_tools: bool) -> 
         )
 
 
-def test_form_prompt_string_with_tools_after_first_system_block_chat_completions() -> None:
-    """Test that tools are inserted after the first consecutive block of system messages."""
+@pytest.mark.parametrize("use_responses", [False, True])
+def test_form_prompt_string_with_tools_after_first_system_block(use_responses: bool) -> None:
+    """Test that tools are inserted after the first consecutive block of system messages in both formats."""
     messages = [
         {"role": "system", "content": "First system message."},
         {"role": "system", "content": "Second system message."},
@@ -990,10 +1015,12 @@ def test_form_prompt_string_with_tools_after_first_system_block_chat_completions
         {"role": "system", "content": "Third system message later."},
         {"role": "user", "content": "Tell me more."},
     ]
-    tools = [
-        {
-            "type": "function",
-            "function": {
+
+    if use_responses:
+        # Responses format includes strict field
+        tools = [
+            {
+                "type": "function",
                 "name": "search",
                 "description": "Search the web for information",
                 "parameters": {
@@ -1001,96 +1028,186 @@ def test_form_prompt_string_with_tools_after_first_system_block_chat_completions
                     "properties": {"query": {"type": "string", "description": "The search query"}},
                     "required": ["query"],
                 },
-            },
-        }
-    ]
+                "strict": True,
+            }
+        ]
+        expected = (
+            "System: First system message.\n\n"
+            "Second system message.\n\n"
+            "You are an AI Assistant that can call provided tools (a.k.a. functions). "
+            "The set of available tools is provided to you as function signatures within "
+            "<tools> </tools> XML tags. "
+            "You may call one or more of these functions to assist with the user query. If the provided functions are not helpful/relevant, "
+            "then just respond in natural conversational language. Don't make assumptions about what values to plug "
+            "into functions. After you choose to call a function, you will be provided with the function's results within "
+            "<tool_response> </tool_response> XML tags.\n\n"
+            "<tools>\n"
+            '{"type":"function","name":"search","description":"Search the web for information","parameters":'
+            '{"type":"object","properties":{"query":{"type":"string","description":"The search query"}},"required":["query"]},'
+            '"strict":true}\n'
+            "</tools>\n\n"
+            "For each function call return a JSON object, with the following pydantic model json schema:\n"
+            "{'name': <function-name>, 'arguments': <args-dict>}\n"
+            "Each function call should be enclosed within <tool_call> </tool_call> XML tags.\n"
+            "Example:\n"
+            "<tool_call>\n"
+            "{'name': <function-name>, 'arguments': <args-dict>}\n"
+            "</tool_call>\n\n"
+            "Note: Your past messages will include a call_id in the <tool_call> XML tags. "
+            "However, do not generate your own call_id when making a function call.\n\n"
+            "User: What can you do?\n\n"
+            "Assistant: I can help you.\n\n"
+            "System: Third system message later.\n\n"
+            "User: Tell me more.\n\n"
+            "Assistant:"
+        )
+    else:
+        # Chat completions format uses nested function structure
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "search",
+                    "description": "Search the web for information",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"query": {"type": "string", "description": "The search query"}},
+                        "required": ["query"],
+                    },
+                },
+            }
+        ]
+        expected = (
+            "System: First system message.\n\n"
+            "Second system message.\n\n"
+            "You are an AI Assistant that can call provided tools (a.k.a. functions). "
+            "The set of available tools is provided to you as function signatures within "
+            "<tools> </tools> XML tags. "
+            "You may call one or more of these functions to assist with the user query. If the provided functions are not helpful/relevant, "
+            "then just respond in natural conversational language. Don't make assumptions about what values to plug "
+            "into functions. After you choose to call a function, you will be provided with the function's results within "
+            "<tool_response> </tool_response> XML tags.\n\n"
+            "<tools>\n"
+            '{"type":"function","function":{"name":"search","description":"Search the web for information","parameters":'
+            '{"type":"object","properties":{"query":{"type":"string","description":"The search query"}},"required":["query"]}}}\n'
+            "</tools>\n\n"
+            "For each function call return a JSON object, with the following pydantic model json schema:\n"
+            "{'name': <function-name>, 'arguments': <args-dict>}\n"
+            "Each function call should be enclosed within <tool_call> </tool_call> XML tags.\n"
+            "Example:\n"
+            "<tool_call>\n"
+            "{'name': <function-name>, 'arguments': <args-dict>}\n"
+            "</tool_call>\n\n"
+            "Note: Your past messages will include a call_id in the <tool_call> XML tags. "
+            "However, do not generate your own call_id when making a function call.\n\n"
+            "User: What can you do?\n\n"
+            "Assistant: I can help you.\n\n"
+            "System: Third system message later.\n\n"
+            "User: Tell me more.\n\n"
+            "Assistant:"
+        )
 
-    result = form_prompt_string(messages, tools)
-
-    expected = (
-        "System: First system message.\n\n"
-        "Second system message.\n\n"
-        "You are a function calling AI model. You are provided with function signatures within <tools> </tools> XML tags. "
-        "You may call one or more functions to assist with the user query. If available tools are not relevant in assisting "
-        "with user query, just respond in natural conversational language. Don't make assumptions about what values to plug "
-        "into functions. After calling & executing the functions, you will be provided with function results within "
-        "<tool_response> </tool_response> XML tags.\n\n"
-        "<tools>\n"
-        '{"type":"function","function":{"name":"search","description":"Search the web for information","parameters":'
-        '{"type":"object","properties":{"query":{"type":"string","description":"The search query"}},"required":["query"]}}}\n'
-        "</tools>\n\n"
-        "For each function call return a JSON object, with the following pydantic model json schema:\n"
-        "{'name': <function-name>, 'arguments': <args-dict>}\n"
-        "Each function call should be enclosed within <tool_call> </tool_call> XML tags.\n"
-        "Example:\n"
-        "<tool_call>\n"
-        "{'name': <function-name>, 'arguments': <args-dict>}\n"
-        "</tool_call>\n\n"
-        "Note: Your past messages will include a call_id in the <tool_call> XML tags. "
-        "However, do not generate your own call_id when making a function call.\n\n"
-        "User: What can you do?\n\n"
-        "Assistant: I can help you.\n\n"
-        "System: Third system message later.\n\n"
-        "User: Tell me more.\n\n"
-        "Assistant:"
-    )
-
+    result = form_prompt_string(messages, tools, use_responses=use_responses)
     assert result == expected
 
 
-def test_form_prompt_string_with_tools_after_first_system_block_responses() -> None:
-    """Test that tools are inserted after the first consecutive block of system messages in responses format."""
+@pytest.mark.parametrize("use_responses", [False, True])
+def test_form_prompt_string_with_empty_tools(use_responses: bool) -> None:
+    """Test that empty tools list is treated the same as None in both formats."""
+    messages = [{"role": "user", "content": "Just one message."}]
+
+    # Test with None
+    result_none = form_prompt_string(messages, tools=None, use_responses=use_responses)
+
+    # Test with empty list
+    result_empty = form_prompt_string(messages, tools=[], use_responses=use_responses)
+
+    # They should be identical
+    assert result_none == result_empty == "Just one message."
+
+
+@pytest.mark.parametrize("use_responses", [False, True])
+def test_form_prompt_string_with_empty_tools_multiple_messages(use_responses: bool) -> None:
+    """Test empty tools list with multiple messages in both formats."""
     messages = [
-        {"role": "system", "content": "First system message."},
-        {"role": "system", "content": "Second system message."},
-        {"role": "user", "content": "What can you do?"},
-        {"role": "assistant", "content": "I can help you."},
-        {"role": "system", "content": "Third system message later."},
-        {"role": "user", "content": "Tell me more."},
-    ]
-    tools = [
-        {
-            "type": "function",
-            "name": "search",
-            "description": "Search the web for information",
-            "parameters": {
-                "type": "object",
-                "properties": {"query": {"type": "string", "description": "The search query"}},
-                "required": ["query"],
-            },
-            "strict": True,
-        }
+        {"role": "user", "content": "Hello!"},
+        {"role": "assistant", "content": "Hi there!"},
+        {"role": "user", "content": "How are you?"},
     ]
 
-    result = form_prompt_string(messages, tools)
+    # Test with None
+    result_none = form_prompt_string(messages, tools=None, use_responses=use_responses)
+
+    # Test with empty list
+    result_empty = form_prompt_string(messages, tools=[], use_responses=use_responses)
+
+    # They should be identical
+    expected = "User: Hello!\n\n" "Assistant: Hi there!\n\n" "User: How are you?\n\n" "Assistant:"
+    assert result_none == result_empty == expected
+
+
+@pytest.mark.parametrize("use_responses", [False, True])
+def test_form_prompt_string_with_empty_arguments(use_responses: bool) -> None:
+    """Test formatting with tool calls having empty arguments string in both formats."""
+    if use_responses:
+        # Responses format
+        messages: list[dict[str, Any]] = [
+            {"role": "user", "content": "Execute the action"},
+            {
+                "type": "function_call",
+                "name": "execute_action",
+                "arguments": "",
+                "call_id": "call_123",
+            },
+            {
+                "type": "function_call_output",
+                "call_id": "call_123",
+                "output": "Action completed successfully",
+            },
+        ]
+    else:
+        # Chat completions format
+        messages = [
+            {"role": "user", "content": "Execute the action"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "id": "call_123",
+                        "function": {
+                            "name": "execute_action",
+                            "arguments": "",
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "name": "execute_action",
+                "tool_call_id": "call_123",
+                "content": "Action completed successfully",
+            },
+        ]
 
     expected = (
-        "System: First system message.\n\n"
-        "Second system message.\n\n"
-        "You are a function calling AI model. You are provided with function signatures within <tools> </tools> XML tags. "
-        "You may call one or more functions to assist with the user query. If available tools are not relevant in assisting "
-        "with user query, just respond in natural conversational language. Don't make assumptions about what values to plug "
-        "into functions. After calling & executing the functions, you will be provided with function results within "
-        "<tool_response> </tool_response> XML tags.\n\n"
-        "<tools>\n"
-        '{"type":"function","name":"search","description":"Search the web for information","parameters":'
-        '{"type":"object","properties":{"query":{"type":"string","description":"The search query"}},"required":["query"]},'
-        '"strict":true}\n'
-        "</tools>\n\n"
-        "For each function call return a JSON object, with the following pydantic model json schema:\n"
-        "{'name': <function-name>, 'arguments': <args-dict>}\n"
-        "Each function call should be enclosed within <tool_call> </tool_call> XML tags.\n"
-        "Example:\n"
-        "<tool_call>\n"
-        "{'name': <function-name>, 'arguments': <args-dict>}\n"
+        "User: Execute the action\n\n"
+        "Assistant: <tool_call>\n"
+        "{\n"
+        '  "name": "execute_action",\n'
+        '  "arguments": {},\n'
+        '  "call_id": "call_123"\n'
+        "}\n"
         "</tool_call>\n\n"
-        "Note: Your past messages will include a call_id in the <tool_call> XML tags. "
-        "However, do not generate your own call_id when making a function call.\n\n"
-        "User: What can you do?\n\n"
-        "Assistant: I can help you.\n\n"
-        "System: Third system message later.\n\n"
-        "User: Tell me more.\n\n"
+        "Tool: "
+        "<tool_response>\n"
+        "{\n"
+        '  "name": "execute_action",\n'
+        '  "call_id": "call_123",\n'
+        '  "output": "Action completed successfully"\n'
+        "}\n"
+        "</tool_response>\n\n"
         "Assistant:"
     )
-
-    assert result == expected
+    assert form_prompt_string(messages, use_responses=use_responses) == expected

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -6,7 +6,7 @@ from cleanlab_tlm.utils.chat import (
     _form_prompt_chat_completions_api,
     _form_prompt_responses_api,
     form_prompt_string,
-    form_prompt_string_chat_completions_api,
+    form_response_string_chat_completions_api,
 )
 
 if TYPE_CHECKING:
@@ -1214,16 +1214,16 @@ def test_form_prompt_string_with_empty_arguments(use_responses: bool) -> None:
     assert form_prompt_string(messages, use_responses=use_responses) == expected
 
 
-def test_form_prompt_string_chat_completions_api_just_content() -> None:
-    """Test form_prompt_string_chat_completions_api with just content."""
+def test_form_response_string_chat_completions_api_just_content() -> None:
+    """Test form_response_string_chat_completions_api with just content."""
     response = {"content": "Hello, how can I help you today?"}
     expected = "Hello, how can I help you today?"
-    result = form_prompt_string_chat_completions_api(response)
+    result = form_response_string_chat_completions_api(response)
     assert result == expected
 
 
-def test_form_prompt_string_chat_completions_api_just_tool_calls() -> None:
-    """Test form_prompt_string_chat_completions_api with just tool calls."""
+def test_form_response_string_chat_completions_api_just_tool_calls() -> None:
+    """Test form_response_string_chat_completions_api with just tool calls."""
     response = {
         "content": "",
         "tool_calls": [
@@ -1245,12 +1245,12 @@ def test_form_prompt_string_chat_completions_api_just_tool_calls() -> None:
         "}\n"
         "</tool_call>"
     )
-    result = form_prompt_string_chat_completions_api(response)
+    result = form_response_string_chat_completions_api(response)
     assert result == expected
 
 
-def test_form_prompt_string_chat_completions_api_content_and_tool_calls() -> None:
-    """Test form_prompt_string_chat_completions_api with both content and tool calls."""
+def test_form_response_string_chat_completions_api_content_and_tool_calls() -> None:
+    """Test form_response_string_chat_completions_api with both content and tool calls."""
     response = {
         "role": "assistant",
         "content": "I'll check the weather for you.",
@@ -1274,12 +1274,12 @@ def test_form_prompt_string_chat_completions_api_content_and_tool_calls() -> Non
         "}\n"
         "</tool_call>"
     )
-    result = form_prompt_string_chat_completions_api(response)
+    result = form_response_string_chat_completions_api(response)
     assert result == expected
 
 
-def test_form_prompt_string_chat_completions_api_multiple_tool_calls() -> None:
-    """Test form_prompt_string_chat_completions_api with multiple tool calls."""
+def test_form_response_string_chat_completions_api_multiple_tool_calls() -> None:
+    """Test form_response_string_chat_completions_api with multiple tool calls."""
     response = {
         "role": "assistant",
         "content": "Let me check multiple things for you.",
@@ -1317,28 +1317,28 @@ def test_form_prompt_string_chat_completions_api_multiple_tool_calls() -> None:
         "}\n"
         "</tool_call>"
     )
-    result = form_prompt_string_chat_completions_api(response)
+    result = form_response_string_chat_completions_api(response)
     assert result == expected
 
 
-def test_form_prompt_string_chat_completions_api_empty_content() -> None:
-    """Test form_prompt_string_chat_completions_api with empty content."""
+def test_form_response_string_chat_completions_api_empty_content() -> None:
+    """Test form_response_string_chat_completions_api with empty content."""
     response = {"content": ""}
     expected = ""
-    result = form_prompt_string_chat_completions_api(response)
+    result = form_response_string_chat_completions_api(response)
     assert result == expected
 
 
-def test_form_prompt_string_chat_completions_api_missing_content() -> None:
-    """Test form_prompt_string_chat_completions_api with missing content key."""
+def test_form_response_string_chat_completions_api_missing_content() -> None:
+    """Test form_response_string_chat_completions_api with missing content key."""
     response: dict[str, Any] = {}
     expected = ""
-    result = form_prompt_string_chat_completions_api(response)
+    result = form_response_string_chat_completions_api(response)
     assert result == expected
 
 
-def test_form_prompt_string_chat_completions_api_empty_arguments() -> None:
-    """Test form_prompt_string_chat_completions_api with empty arguments."""
+def test_form_response_string_chat_completions_api_empty_arguments() -> None:
+    """Test form_response_string_chat_completions_api with empty arguments."""
     response = {
         "role": "assistant",
         "content": "Running action",
@@ -1360,24 +1360,24 @@ def test_form_prompt_string_chat_completions_api_empty_arguments() -> None:
         "}\n"
         "</tool_call>"
     )
-    result = form_prompt_string_chat_completions_api(response)
+    result = form_response_string_chat_completions_api(response)
     assert result == expected
 
 
-def test_form_prompt_string_chat_completions_api_invalid_input() -> None:
-    """Test form_prompt_string_chat_completions_api raises TypeError for invalid input."""
+def test_form_response_string_chat_completions_api_invalid_input() -> None:
+    """Test form_response_string_chat_completions_api raises TypeError for invalid input."""
     with pytest.raises(TypeError, match="Expected response to be a dict, got str"):
-        form_prompt_string_chat_completions_api("not a dict")  # type: ignore[arg-type]
+        form_response_string_chat_completions_api("not a dict")  # type: ignore[arg-type]
 
     with pytest.raises(TypeError, match="Expected response to be a dict, got list"):
-        form_prompt_string_chat_completions_api([])  # type: ignore[arg-type]
+        form_response_string_chat_completions_api([])  # type: ignore[arg-type]
 
     with pytest.raises(TypeError, match="Expected response to be a dict, got NoneType"):
-        form_prompt_string_chat_completions_api(None)  # type: ignore[arg-type]
+        form_response_string_chat_completions_api(None)  # type: ignore[arg-type]
 
 
-def test_form_prompt_string_chat_completions_api_malformed_tool_calls() -> None:
-    """Test form_prompt_string_chat_completions_api handles malformed tool calls gracefully."""
+def test_form_response_string_chat_completions_api_malformed_tool_calls() -> None:
+    """Test form_response_string_chat_completions_api handles malformed tool calls gracefully."""
     # Test with missing function key - this should trigger a warning
     response = {
         "role": "assistant",
@@ -1386,7 +1386,7 @@ def test_form_prompt_string_chat_completions_api_malformed_tool_calls() -> None:
     }
 
     with pytest.warns(UserWarning, match="Error formatting tool_calls in response: 'function'"):
-        result = form_prompt_string_chat_completions_api(response)
+        result = form_response_string_chat_completions_api(response)
         assert result == "I'll help you."
 
     # Test with invalid JSON in arguments - this should trigger a warning
@@ -1404,5 +1404,5 @@ def test_form_prompt_string_chat_completions_api_malformed_tool_calls() -> None:
 
     # Warning expected since JSON parsing will fail
     with pytest.warns(UserWarning, match="Error formatting tool_calls in response.*Returning content only"):
-        result = form_prompt_string_chat_completions_api(response)
+        result = form_response_string_chat_completions_api(response)
         assert result == "Let me check that."


### PR DESCRIPTION
Representative test case:

```python
def test_form_response_string_chat_completions_api_content_and_tool_calls() -> None:
    """Test form_response_string_chat_completions_api with both content and tool calls."""
    response = {
        "role": "assistant",
        "content": "I'll check the weather for you.",
        "tool_calls": [
            {
                "function": {
                    "name": "get_weather",
                    "arguments": '{"location": "Paris"}',
                }
            }
        ],
    }
    expected = (
        "I'll check the weather for you.\n"
        "<tool_call>\n"
        "{\n"
        '  "name": "get_weather",\n'
        '  "arguments": {\n'
        '    "location": "Paris"\n'
        "  }\n"
        "}\n"
        "</tool_call>"
    )
    result = form_response_string_chat_completions_api(response)
    assert result == expected
```

I'm handling the Chat Completion API separately here because the output format for the Responses API is completely different. In the Responses API, `content` and `tool_calls` are returned as distinct items in a list (as opposed to being within the same dictionary). For example:
```python
ResponseOutputMessage(
    id='msg_6859de0030f481a191521e9e9399c82604a9b9d4f9e36a68',
    content=[ResponseOutputText(
        annotations=[],
        text="I'll check the current weather in Paris for you.",
        type='output_text',
        logprobs=None
    )],
    role='assistant',
    status='completed',
    type='message'
)
```

```python
ResponseFunctionToolCall(
    arguments='{"latitude":48.8566,"longitude":2.3522}',
    call_id='call_TmDhi6AHT2yz9zvmTqII7qjC',
    name='get_weather',
    type='function_call',
    id='fc_6859de00b1b481a1851d879d907d6d5904a9b9d4f9e36a68',
    status='completed'
)
```


