### PR TITLE
Move `get_model_name` method to BaseTLM class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.19] - 2025-07-25
+
+### Added
+
+- Add `get_model_name()` method to `TrustworthyRAG`, `TLMChatCompletion`
+
+
 ## [1.1.18] - 2025-07-25
 
 ### Fixed
 
 - Properly pass quality preset in `TLMChatCompletion`
+
 
 ## [1.1.17] - 2025-07-18
 
@@ -265,7 +273,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Release of the Cleanlab TLM Python client.
 
 
-[Unreleased]: https://github.com/cleanlab/cleanlab-tlm/compare/v1.1.18...HEAD
+[Unreleased]: https://github.com/cleanlab/cleanlab-tlm/compare/v1.1.19...HEAD
+[1.1.19]: https://github.com/cleanlab/cleanlab-tlm/compare/v1.1.18...v1.1.19
 [1.1.18]: https://github.com/cleanlab/cleanlab-tlm/compare/v1.1.17...v1.1.18
 [1.1.17]: https://github.com/cleanlab/cleanlab-tlm/compare/v1.1.16...v1.1.17
 [1.1.16]: https://github.com/cleanlab/cleanlab-tlm/compare/v1.1.15...v1.1.16

--- a/src/cleanlab_tlm/__about__.py
+++ b/src/cleanlab_tlm/__about__.py
@@ -1,2 +1,2 @@
 # SPDX-License-Identifier: MIT
-__version__ = "1.1.18"
+__version__ = "1.1.19"

--- a/src/cleanlab_tlm/internal/base.py
+++ b/src/cleanlab_tlm/internal/base.py
@@ -105,6 +105,6 @@ class BaseTLM:
 
     def get_model_name(self) -> str:
         """Returns the underlying LLM used to generate responses and score their trustworthiness.
-        Available base LLMs that you can run TLM with are listed under "model" configuration in [TLMOptions](#class-tlmoptions).
+        Available base LLMs that you can run TLM with are listed under "model" configuration in TLMOptions.
         """
         return cast(str, self._options["model"])

--- a/src/cleanlab_tlm/internal/base.py
+++ b/src/cleanlab_tlm/internal/base.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import asyncio
 import os
 import sys
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Optional, Union, cast
 
 from cleanlab_tlm.errors import MissingApiKeyError, ValidationError
 from cleanlab_tlm.internal.concurrency import TlmRateHandler
@@ -102,3 +102,9 @@ class BaseTLM:
         except RuntimeError:
             self._event_loop = asyncio.new_event_loop()
         self._rate_handler = TlmRateHandler()
+
+    def get_model_name(self) -> str:
+        """Returns the underlying LLM used to generate responses and score their trustworthiness.
+        Available base LLMs that you can run TLM with are listed under "model" configuration in [TLMOptions](#class-tlmoptions).
+        """
+        return cast(str, self._options["model"])

--- a/src/cleanlab_tlm/tlm.py
+++ b/src/cleanlab_tlm/tlm.py
@@ -531,12 +531,6 @@ class TLM(BaseTLM):
 
         return {"trustworthiness_score": response_json["confidence_score"]}
 
-    def get_model_name(self) -> str:
-        """Returns the underlying LLM used to generate responses and score their trustworthiness.
-        Available base LLMs that you can run TLM with are listed under "model" configuration in [TLMOptions](#class-tlmoptions).
-        """
-        return cast(str, self._options["model"])
-
 
 class TLMResponse(TypedDict):
     """A typed dict containing the response, trustworthiness score, and additional logs output by the Trustworthy Language Model.

--- a/tests/test_chat_completions.py
+++ b/tests/test_chat_completions.py
@@ -11,6 +11,7 @@ from openai.types.completion_usage import (
     PromptTokensDetails,
 )
 
+from cleanlab_tlm.internal.constants import _TLM_DEFAULT_MODEL
 from cleanlab_tlm.internal.types import TLMQualityPreset
 from cleanlab_tlm.tlm import TLMScore
 from cleanlab_tlm.utils.chat_completions import TLMChatCompletion
@@ -20,6 +21,14 @@ from tests.test_get_trustworthiness_score import is_trustworthiness_score_json_f
 
 test_prompt = make_text_unique(TEST_PROMPT)
 test_response = make_text_unique(TEST_RESPONSE)
+
+
+def test_get_model_name() -> None:
+    tlm = TLMChatCompletion()
+    model_name = tlm.get_model_name()
+
+    assert model_name == tlm._options["model"]
+    assert model_name == _TLM_DEFAULT_MODEL
 
 
 @pytest.mark.parametrize(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,6 +2,7 @@ import pytest
 import tiktoken
 
 from cleanlab_tlm.errors import TlmBadRequestError
+from cleanlab_tlm.internal.constants import _TLM_DEFAULT_MODEL
 from cleanlab_tlm.tlm import TLM
 from cleanlab_tlm.utils.config import (
     get_default_context_limit,
@@ -12,6 +13,13 @@ from cleanlab_tlm.utils.config import (
 from tests.constants import WORD_THAT_EQUALS_ONE_TOKEN
 
 tlm_with_default_setting = TLM()
+
+
+def test_get_model_name(tlm: TLM) -> None:
+    model_name = tlm.get_model_name()
+
+    assert model_name == tlm._options["model"]
+    assert model_name == _TLM_DEFAULT_MODEL
 
 
 def test_get_default_model(tlm: TLM) -> None:

--- a/tests/test_tlm_rag.py
+++ b/tests/test_tlm_rag.py
@@ -201,6 +201,13 @@ def test_init_with_quality_preset(trustworthy_rag_api_key: str, quality_preset: 
     assert tlm_rag._quality_preset == quality_preset
 
 
+def test_get_model_name(trustworthy_rag: TrustworthyRAG) -> None:
+    model_name = trustworthy_rag.get_model_name()
+
+    assert model_name == trustworthy_rag._options["model"]
+    assert model_name == _TLM_DEFAULT_MODEL
+
+
 def test_get_evals(trustworthy_rag: TrustworthyRAG) -> None:
     evals = trustworthy_rag.get_evals()
 


### PR DESCRIPTION
Allows the use of `get_model_name` in `TrustworthyRAG`, `TLMChatCompletion` etc.