### PR TITLE
allow passing request headers into BaseTLM client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.21] - 2025-07-28
+
+### Changed
+
+- Updated the VPC version of `TLMChatCompletion` to accept `request_headers` parameter, which is forwarded to the TLM app as part of API requests
+
 ## [1.1.20] - 2025-07-28
 
 ### Changed
@@ -279,7 +285,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Release of the Cleanlab TLM Python client.
 
 
-[Unreleased]: https://github.com/cleanlab/cleanlab-tlm/compare/v1.1.20...HEAD
+[Unreleased]: https://github.com/cleanlab/cleanlab-tlm/compare/v1.1.21...HEAD
+[1.1.21]: https://github.com/cleanlab/cleanlab-tlm/compare/v1.1.20...v1.1.21
 [1.1.20]: https://github.com/cleanlab/cleanlab-tlm/compare/v1.1.19...v1.1.20
 [1.1.19]: https://github.com/cleanlab/cleanlab-tlm/compare/v1.1.18...v1.1.19
 [1.1.18]: https://github.com/cleanlab/cleanlab-tlm/compare/v1.1.17...v1.1.18

--- a/src/cleanlab_tlm/__about__.py
+++ b/src/cleanlab_tlm/__about__.py
@@ -1,2 +1,2 @@
 # SPDX-License-Identifier: MIT
-__version__ = "1.1.20"
+__version__ = "1.1.21"

--- a/src/cleanlab_tlm/internal/base.py
+++ b/src/cleanlab_tlm/internal/base.py
@@ -41,7 +41,6 @@ class BaseTLM:
         timeout: Optional[float] = None,
         verbose: Optional[bool] = None,
         allow_custom_model: bool = False,
-        request_headers: Optional[dict[str, str]] = None,
     ) -> None:
         """
         Initialize base TLM functionality.
@@ -55,8 +54,6 @@ class BaseTLM:
             timeout: Timeout (in seconds) to apply to each TLM prompt.
             verbose: Whether to print outputs during execution.
         """
-        self._request_headers = request_headers or {}
-
         self._api_key = api_key or os.environ.get("CLEANLAB_TLM_API_KEY")
         if self._api_key is None:
             raise MissingApiKeyError

--- a/src/cleanlab_tlm/internal/base.py
+++ b/src/cleanlab_tlm/internal/base.py
@@ -41,6 +41,7 @@ class BaseTLM:
         timeout: Optional[float] = None,
         verbose: Optional[bool] = None,
         allow_custom_model: bool = False,
+        request_headers: Optional[dict[str, str]] = None,
     ) -> None:
         """
         Initialize base TLM functionality.
@@ -54,6 +55,8 @@ class BaseTLM:
             timeout: Timeout (in seconds) to apply to each TLM prompt.
             verbose: Whether to print outputs during execution.
         """
+        self._request_headers = request_headers or {}
+
         self._api_key = api_key or os.environ.get("CLEANLAB_TLM_API_KEY")
         if self._api_key is None:
             raise MissingApiKeyError

--- a/src/cleanlab_tlm/utils/vpc/chat_completions.py
+++ b/src/cleanlab_tlm/utils/vpc/chat_completions.py
@@ -48,6 +48,7 @@ class TLMChatCompletion(BaseTLM):
         *,
         options: Optional[TLMOptions] = None,
         timeout: Optional[float] = None,
+        request_headers: Optional[dict[str, str]] = None,
     ):
         """
         lazydocs: ignore
@@ -61,6 +62,7 @@ class TLMChatCompletion(BaseTLM):
             timeout=timeout,
             verbose=False,
             allow_custom_model=True,
+            request_headers=request_headers,
         )
 
     def score(
@@ -93,6 +95,7 @@ class TLMChatCompletion(BaseTLM):
                 **openai_kwargs,
             },
             timeout=self._timeout,
+            headers=self._request_headers,
         )
 
         res_json = res.json()

--- a/src/cleanlab_tlm/utils/vpc/chat_completions.py
+++ b/src/cleanlab_tlm/utils/vpc/chat_completions.py
@@ -62,8 +62,8 @@ class TLMChatCompletion(BaseTLM):
             timeout=timeout,
             verbose=False,
             allow_custom_model=True,
-            request_headers=request_headers,
         )
+        self._request_headers = request_headers or {}
 
     def score(
         self,


### PR DESCRIPTION
<!-- TODO: Delete anything from this template that doesn't apply -->

## Key Info

- GenRe is experiencing a bug when using `TLMChatCompletion.score` because the auth header isn't being forwarded to the TLM app and thus the request can't be authenticated and fails
- Priority: urgent
<!-- priority is low, normal, or urgent; for low or urgent, include your expected deadline -->

## What changed?
Add `request_headers` parameter to constructor of `BaseTLM` and `TLMChatCompletion` so that these headers will be reused for all requests made to the TLM app.

## What do you want the reviewer(s) to focus on?
just sanity check that this change makes sense

---
