### PR TITLE
Add arg to skip trustworthiness scoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.1.23] - 2025-08-01
+## [1.1.23] - 2025-08-04
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.23] - 2025-08-01
+
+### Changed
+
+- Updated `TLMOptions` to support `disable_trustworthiness` parameter
+    - Skips trustworthiness scoring when `disable_trustworthiness` is True, assuming either custom evaluation criteria (TLM) or RAG Evals (TrustworthyRAG) are provided
+
+
 ## [1.1.22] - 2025-07-29
 
 ### Added
@@ -291,7 +299,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Release of the Cleanlab TLM Python client.
 
 
-[Unreleased]: https://github.com/cleanlab/cleanlab-tlm/compare/v1.1.22...HEAD
+[Unreleased]: https://github.com/cleanlab/cleanlab-tlm/compare/v1.1.23...HEAD
+[1.1.23]: https://github.com/cleanlab/cleanlab-tlm/compare/v1.1.22...v1.1.23
 [1.1.22]: https://github.com/cleanlab/cleanlab-tlm/compare/v1.1.21...v1.1.22
 [1.1.21]: https://github.com/cleanlab/cleanlab-tlm/compare/v1.1.20...v1.1.21
 [1.1.20]: https://github.com/cleanlab/cleanlab-tlm/compare/v1.1.19...v1.1.20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.1.23] - 2025-08-04
+## [1.1.23] - 2025-08-05
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.1.23] - 2025-08-05
+## [1.1.23] - 2025-08-06
 
 ### Changed
 

--- a/src/cleanlab_tlm/__about__.py
+++ b/src/cleanlab_tlm/__about__.py
@@ -1,2 +1,2 @@
 # SPDX-License-Identifier: MIT
-__version__ = "1.1.22"
+__version__ = "1.1.23"

--- a/src/cleanlab_tlm/internal/validation.py
+++ b/src/cleanlab_tlm/internal/validation.py
@@ -198,6 +198,11 @@ def validate_tlm_options(
 
                 if not isinstance(criteria.get("criteria"), str):
                     raise ValidationError(f"'criteria' in custom_eval_criteria item {i} must be a string.")
+        elif option == "disable_trustworthiness":
+            if not isinstance(val, bool):
+                raise ValidationError(f"Invalid type {type(val)}, disable_trustworthiness must be a boolean")
+            if val and support_custom_eval_criteria and not options.get("custom_eval_criteria"):
+                raise ValidationError("disable_trustworthiness is only supported when custom_eval_criteria is provided")
 
 
 def process_and_validate_kwargs_constrain_outputs(

--- a/src/cleanlab_tlm/tlm.py
+++ b/src/cleanlab_tlm/tlm.py
@@ -613,12 +613,14 @@ class TLMOptions(TypedDict):
         num_self_reflections (int, default = 3): the number of different evaluations to perform where the LLM reflects on the response, a factor affecting trust scoring.
         The maximum number currently supported is 3. Lower values can reduce runtimes.
         Reflection helps quantify aleatoric uncertainty associated with challenging prompts and catches responses that are noticeably incorrect/bad upon further analysis.
+        This parameter has no effect when `disable_trustworthiness` is True.
 
         num_consistency_samples (int, default = 8): the amount of internal sampling to measure LLM response consistency, a factor affecting trust scoring.
         Must be between 0 and 20. Lower values can reduce runtimes.
         Measuring consistency helps quantify the epistemic uncertainty associated with
         strange prompts or prompts that are too vague/open-ended to receive a clearly defined 'good' response.
         TLM measures consistency via the degree of contradiction between sampled responses that the model considers plausible.
+        This parameter has no effect when `disable_trustworthiness` is True.
 
         similarity_measure ({"semantic", "string", "embedding", "embedding_large", "code", "discrepancy"}, default = "discrepancy"): how the
         trustworthiness scoring's consistency algorithm measures similarity between alternative responses considered plausible by the model.
@@ -633,9 +635,11 @@ class TLMOptions(TypedDict):
         You can auto-improve responses by increasing this parameter, but at higher runtimes/costs.
         This parameter must be between 1 and 20. It has no effect on `TLM.score()`.
         When this parameter is 1, `TLM.prompt()` simply returns a standard LLM response and does not attempt to auto-improve it.
+        This parameter has no effect when `disable_trustworthiness` is True.
 
         disable_trustworthiness (bool, default = False): if True, trustworthiness scoring is disabled and TLM will not compute trust scores for responses.
         This is useful when you only want to use custom evaluation criteria or when you want to minimize computational overhead and only need the base LLM response.
+        The following parameters will be ignored when `disable_trustworthiness` is True: `num_consistency_samples`, `num_self_reflections`, `num_candidate_responses`.
     """
 
     model: NotRequired[str]

--- a/src/cleanlab_tlm/tlm.py
+++ b/src/cleanlab_tlm/tlm.py
@@ -633,6 +633,10 @@ class TLMOptions(TypedDict):
         You can auto-improve responses by increasing this parameter, but at higher runtimes/costs.
         This parameter must be between 1 and 20. It has no effect on `TLM.score()`.
         When this parameter is 1, `TLM.prompt()` simply returns a standard LLM response and does not attempt to auto-improve it.
+        
+        disable_trustworthiness (bool, default = False): if True, trustworthiness scoring is disabled and TLM will not compute trust scores for responses.
+        This is useful when you only want to use custom evaluation criteria or when you want to minimize computational overhead and only need the base LLM response.
+        
     """
 
     model: NotRequired[str]
@@ -645,3 +649,4 @@ class TLMOptions(TypedDict):
     reasoning_effort: NotRequired[str]
     log: NotRequired[list[str]]
     custom_eval_criteria: NotRequired[list[dict[str, Any]]]
+    disable_trustworthiness: NotRequired[bool]

--- a/src/cleanlab_tlm/tlm.py
+++ b/src/cleanlab_tlm/tlm.py
@@ -633,10 +633,9 @@ class TLMOptions(TypedDict):
         You can auto-improve responses by increasing this parameter, but at higher runtimes/costs.
         This parameter must be between 1 and 20. It has no effect on `TLM.score()`.
         When this parameter is 1, `TLM.prompt()` simply returns a standard LLM response and does not attempt to auto-improve it.
-        
+
         disable_trustworthiness (bool, default = False): if True, trustworthiness scoring is disabled and TLM will not compute trust scores for responses.
         This is useful when you only want to use custom evaluation criteria or when you want to minimize computational overhead and only need the base LLM response.
-        
     """
 
     model: NotRequired[str]

--- a/src/cleanlab_tlm/utils/rag.py
+++ b/src/cleanlab_tlm/utils/rag.py
@@ -132,21 +132,17 @@ class TrustworthyRAG(BaseTLM):
 
             self._evals = evals
 
-        # Check if trustworthiness is disabled but no evaluations are available
-        if options and options.get("disable_trustworthiness", False):
-            if not self._evals:
-                if evals is None:
-                    # This shouldn't happen if _DEFAULT_EVALS is properly configured, but defensive check
-                    raise ValidationError(
-                        f"Cannot disable trustworthiness scoring in {self.__class__.__name__}: no evaluation criteria available. "
-                        "Please provide evaluations via the 'evals' parameter or set disable_trustworthiness=False."
-                    )
-                else:
-                    # User explicitly provided empty evals list
-                    raise ValidationError(
-                        f"When disable_trustworthiness=True in {self.__class__.__name__}, at least one evaluation must be provided. "
-                        "Either provide evaluations via the 'evals' parameter or set disable_trustworthiness=False."
-                    )
+        self._validate_disable_trustworthiness_option(options)
+
+    def _validate_disable_trustworthiness_option(self, options: Optional[TLMOptions]) -> None:
+        """Validate that when trustworthiness scoring is disabled, alternative evaluations are available."""
+        disable_trustworthiness = options and options.get("disable_trustworthiness", False)
+
+        if disable_trustworthiness and not self._evals:
+            raise ValidationError(
+                f"When disable_trustworthiness=True in {self.__class__.__name__}, at least one evaluation must be provided. "
+                "Either provide evaluations via the 'evals' parameter or set disable_trustworthiness=False."
+            )
 
     def score(
         self,

--- a/src/cleanlab_tlm/utils/rag.py
+++ b/src/cleanlab_tlm/utils/rag.py
@@ -42,6 +42,7 @@ from cleanlab_tlm.internal.constants import (
 )
 from cleanlab_tlm.internal.exception_handling import handle_tlm_exceptions
 from cleanlab_tlm.internal.validation import (
+    _validate_trustworthy_rag_options,
     tlm_score_process_response_and_kwargs,
     validate_rag_inputs,
 )
@@ -132,17 +133,7 @@ class TrustworthyRAG(BaseTLM):
 
             self._evals = evals
 
-        self._validate_disable_trustworthiness_option(options)
-
-    def _validate_disable_trustworthiness_option(self, options: Optional[TLMOptions]) -> None:
-        """Validate that when trustworthiness scoring is disabled, alternative evaluations are available."""
-        disable_trustworthiness = options and options.get("disable_trustworthiness", False)
-
-        if disable_trustworthiness and not self._evals:
-            raise ValidationError(
-                f"When disable_trustworthiness=True in {self.__class__.__name__}, at least one evaluation must be provided. "
-                "Either provide evaluations via the 'evals' parameter or set disable_trustworthiness=False."
-            )
+        _validate_trustworthy_rag_options(options=options, initialized_evals=self._evals)
 
     def score(
         self,

--- a/tests/test_get_trustworthiness_score.py
+++ b/tests/test_get_trustworthiness_score.py
@@ -203,3 +203,26 @@ def reset_tlm(tlm: TLM) -> Generator[None, None, None]:
     original_timeout = tlm._timeout
     yield
     tlm._timeout = original_timeout
+
+
+def test_get_trustworthiness_score_with_disable_trustworthiness(tlm_api_key: str) -> None:
+    """Tests get_trustworthiness_score with disable_trustworthiness option.
+
+    When disable_trustworthiness is enabled (along with custom_eval_criteria),
+    the trustworthiness_score should be None in the response.
+
+    Expected:
+    - TLM should return a response
+    - trustworthiness_score should be None
+    - No exceptions are raised
+    """
+    tlm = TLM(
+        api_key=tlm_api_key,
+        options={
+            "disable_trustworthiness": True,
+            "custom_eval_criteria": [{"name": "test", "criteria": "test criteria"}],
+        },
+    )
+    response = tlm.get_trustworthiness_score(test_prompt, TEST_RESPONSE)
+    assert not isinstance(response, list)
+    assert response["trustworthiness_score"] is None

--- a/tests/test_tlm_rag.py
+++ b/tests/test_tlm_rag.py
@@ -962,3 +962,30 @@ def reset_rag_timeout(trustworthy_rag: TrustworthyRAG) -> Generator[None, None, 
     old_timeout = trustworthy_rag._timeout
     yield
     trustworthy_rag._timeout = old_timeout
+
+
+def test_score_with_disable_trustworthiness(trustworthy_rag_api_key: str) -> None:
+    """Tests score with disable_trustworthiness option.
+
+    When disable_trustworthiness is enabled (along with valid evals),
+    the trustworthiness score should be None in the response.
+
+    Expected:
+    - TrustworthyRAG should return a response
+    - response should have the trustworthiness key
+    - trustworthiness score should be None
+    - No exceptions are raised
+    """
+    trustworthy_rag = TrustworthyRAG(
+        api_key=trustworthy_rag_api_key,
+        options={"disable_trustworthiness": True},
+    )
+    response = trustworthy_rag.score(
+        query=test_query,
+        context=test_context,
+        response=test_response,
+        prompt=test_prompt,
+    )
+    assert not isinstance(response, list)
+    assert "trustworthiness" in response
+    assert response["trustworthiness"]["score"] is None

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -821,16 +821,17 @@ def test_disable_trustworthiness_without_custom_criteria_raises_error(tlm_api_ke
     with pytest.raises(
         ValidationError, match="^disable_trustworthiness is only supported when custom_eval_criteria is provided"
     ):
-        TLM(api_key=tlm_api_key, options=TLMOptions(disable_trustworthiness=True))
+        TLM(api_key=tlm_api_key, options={"disable_trustworthiness": True})
 
 
 def test_disable_trustworthiness_with_custom_criteria_works(tlm_api_key: str) -> None:
     """Test that disable_trustworthiness=True with custom_eval_criteria works normally."""
     TLM(
         api_key=tlm_api_key,
-        options=TLMOptions(
-            disable_trustworthiness=True, custom_eval_criteria=[{"name": "test", "criteria": "test criteria"}]
-        ),
+        options={
+            "disable_trustworthiness": True,
+            "custom_eval_criteria": [{"name": "test", "criteria": "test criteria"}],
+        },
     )
 
 
@@ -839,11 +840,11 @@ def test_disable_trustworthiness_without_custom_criteria_raises_error_rag(tlm_ap
     from cleanlab_tlm.utils.rag import TrustworthyRAG
 
     with pytest.raises(ValidationError, match="^When disable_trustworthiness=True in TrustworthyRAG"):
-        TrustworthyRAG(evals=[], api_key=tlm_api_key, options=TLMOptions(disable_trustworthiness=True))
+        TrustworthyRAG(evals=[], api_key=tlm_api_key, options={"disable_trustworthiness": True})
 
 
 def test_disable_trustworthiness_with_custom_criteria_works_rag(tlm_api_key: str) -> None:
     """Test that disable_trustworthiness=True with custom_eval_criteria works normally for TrustworthyRAG."""
     from cleanlab_tlm.utils.rag import TrustworthyRAG
 
-    TrustworthyRAG(api_key=tlm_api_key, options=TLMOptions(disable_trustworthiness=True))
+    TrustworthyRAG(api_key=tlm_api_key, options={"disable_trustworthiness": True})

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -689,7 +689,7 @@ def test_validate_tlm_options_support_custom_eval_criteria() -> None:
 
     # Valid with disable_trustworthiness=True and custom_eval_criteria
     validate_tlm_options({**options, "disable_trustworthiness": True}, support_custom_eval_criteria=True)
-    
+
     # Invalid: disable_trustworthiness=True without custom_eval_criteria
     with pytest.raises(ValidationError, match="^disable_trustworthiness is only supported when custom_eval_criteria is provided"):
         validate_tlm_options({"disable_trustworthiness": True}, support_custom_eval_criteria=True)
@@ -823,7 +823,7 @@ def test_disable_trustworthiness_with_custom_criteria_works(tlm_api_key: str) ->
 def test_disable_trustworthiness_without_custom_criteria_raises_error_rag(tlm_api_key: str) -> None:
     """Test that disable_trustworthiness=True without custom_eval_criteria raises ValueError for TrustworthyRAG."""
     from cleanlab_tlm.utils.rag import TrustworthyRAG
-    
+
     with pytest.raises(ValidationError, match="^When disable_trustworthiness=True in TrustworthyRAG") :
         TrustworthyRAG(evals=[],api_key=tlm_api_key, options=TLMOptions(disable_trustworthiness=True))
 
@@ -831,6 +831,6 @@ def test_disable_trustworthiness_without_custom_criteria_raises_error_rag(tlm_ap
 def test_disable_trustworthiness_with_custom_criteria_works_rag(tlm_api_key: str) -> None:
     """Test that disable_trustworthiness=True with custom_eval_criteria works normally for TrustworthyRAG."""
     from cleanlab_tlm.utils.rag import TrustworthyRAG
-    
+
     TrustworthyRAG(api_key=tlm_api_key, options=TLMOptions(disable_trustworthiness=True))
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -809,13 +809,28 @@ def test_validate_rag_inputs_matching_lists() -> None:
     assert result[1] == "Q: query 2 C: context 2"
 
 
-# def test_disable_trustworthiness_without_custom_criteria_raises_error(tlm_api_key: str) -> None:
-#     """Test that disable_trustworthiness=True without custom_eval_criteria raises ValueError."""
-#     with pytest.raises(ValueError) as exc_info:
-#         tlm = TLM(api_key=tlm_api_key, options=TLMOptions(disable_trustworthiness=True))
-#     assert "Trustworthiness is disabled but no alternative evaluation criteria was provided" in str(exc_info.value)
+def test_disable_trustworthiness_without_custom_criteria_raises_error(tlm_api_key: str) -> None:
+    """Test that disable_trustworthiness=True without custom_eval_criteria raises ValueError."""
+    with pytest.raises(ValidationError, match="^disable_trustworthiness is only supported when custom_eval_criteria is provided"):
+        TLM(api_key=tlm_api_key, options=TLMOptions(disable_trustworthiness=True))
 
-# def test_disable_trustworthiness_with_custom_criteria_works(tlm_api_key: str) -> None:
-#     """Test that disable_trustworthiness=True with custom_eval_criteria works normally."""
-#     tlm = TLM(api_key=tlm_api_key, options=TLMOptions(disable_trustworthiness=True, custom_eval_criteria=[{"name": "test", "criteria": "test criteria"}]))
-#     assert tlm is not None
+def test_disable_trustworthiness_with_custom_criteria_works(tlm_api_key: str) -> None:
+    """Test that disable_trustworthiness=True with custom_eval_criteria works normally."""
+    TLM(api_key=tlm_api_key, options=TLMOptions(disable_trustworthiness=True, custom_eval_criteria=[{"name": "test", "criteria": "test criteria"}]))
+
+
+
+def test_disable_trustworthiness_without_custom_criteria_raises_error_rag(tlm_api_key: str) -> None:
+    """Test that disable_trustworthiness=True without custom_eval_criteria raises ValueError for TrustworthyRAG."""
+    from cleanlab_tlm.utils.rag import TrustworthyRAG
+    
+    with pytest.raises(ValidationError, match="^When disable_trustworthiness=True in TrustworthyRAG") :
+        TrustworthyRAG(evals=[],api_key=tlm_api_key, options=TLMOptions(disable_trustworthiness=True))
+
+
+def test_disable_trustworthiness_with_custom_criteria_works_rag(tlm_api_key: str) -> None:
+    """Test that disable_trustworthiness=True with custom_eval_criteria works normally for TrustworthyRAG."""
+    from cleanlab_tlm.utils.rag import TrustworthyRAG
+    
+    TrustworthyRAG(api_key=tlm_api_key, options=TLMOptions(disable_trustworthiness=True))
+

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -691,11 +691,18 @@ def test_validate_tlm_options_support_custom_eval_criteria() -> None:
     validate_tlm_options({**options, "disable_trustworthiness": True}, support_custom_eval_criteria=True)
 
     # Invalid: disable_trustworthiness=True without custom_eval_criteria
-    with pytest.raises(ValidationError, match="^disable_trustworthiness is only supported when custom_eval_criteria is provided"):
+    with pytest.raises(
+        ValidationError, match="^disable_trustworthiness is only supported when custom_eval_criteria is provided"
+    ):
         validate_tlm_options({"disable_trustworthiness": True}, support_custom_eval_criteria=True)
 
-    with pytest.raises(ValidationError, match="^disable_trustworthiness is only supported when custom_eval_criteria is provided"):
-        validate_tlm_options({"disable_trustworthiness": True, "custom_eval_criteria": None}, support_custom_eval_criteria=True)
+    with pytest.raises(
+        ValidationError, match="^disable_trustworthiness is only supported when custom_eval_criteria is provided"
+    ):
+        validate_tlm_options(
+            {"disable_trustworthiness": True, "custom_eval_criteria": None}, support_custom_eval_criteria=True
+        )
+
 
 def test_validate_rag_inputs_mixed_string_and_sequence() -> None:
     """Tests that validate_rag_inputs rejects mixed inputs where some are strings and others are sequences."""
@@ -811,21 +818,28 @@ def test_validate_rag_inputs_matching_lists() -> None:
 
 def test_disable_trustworthiness_without_custom_criteria_raises_error(tlm_api_key: str) -> None:
     """Test that disable_trustworthiness=True without custom_eval_criteria raises ValueError."""
-    with pytest.raises(ValidationError, match="^disable_trustworthiness is only supported when custom_eval_criteria is provided"):
+    with pytest.raises(
+        ValidationError, match="^disable_trustworthiness is only supported when custom_eval_criteria is provided"
+    ):
         TLM(api_key=tlm_api_key, options=TLMOptions(disable_trustworthiness=True))
+
 
 def test_disable_trustworthiness_with_custom_criteria_works(tlm_api_key: str) -> None:
     """Test that disable_trustworthiness=True with custom_eval_criteria works normally."""
-    TLM(api_key=tlm_api_key, options=TLMOptions(disable_trustworthiness=True, custom_eval_criteria=[{"name": "test", "criteria": "test criteria"}]))
-
+    TLM(
+        api_key=tlm_api_key,
+        options=TLMOptions(
+            disable_trustworthiness=True, custom_eval_criteria=[{"name": "test", "criteria": "test criteria"}]
+        ),
+    )
 
 
 def test_disable_trustworthiness_without_custom_criteria_raises_error_rag(tlm_api_key: str) -> None:
     """Test that disable_trustworthiness=True without custom_eval_criteria raises ValueError for TrustworthyRAG."""
     from cleanlab_tlm.utils.rag import TrustworthyRAG
 
-    with pytest.raises(ValidationError, match="^When disable_trustworthiness=True in TrustworthyRAG") :
-        TrustworthyRAG(evals=[],api_key=tlm_api_key, options=TLMOptions(disable_trustworthiness=True))
+    with pytest.raises(ValidationError, match="^When disable_trustworthiness=True in TrustworthyRAG"):
+        TrustworthyRAG(evals=[], api_key=tlm_api_key, options=TLMOptions(disable_trustworthiness=True))
 
 
 def test_disable_trustworthiness_with_custom_criteria_works_rag(tlm_api_key: str) -> None:
@@ -833,4 +847,3 @@ def test_disable_trustworthiness_with_custom_criteria_works_rag(tlm_api_key: str
     from cleanlab_tlm.utils.rag import TrustworthyRAG
 
     TrustworthyRAG(api_key=tlm_api_key, options=TLMOptions(disable_trustworthiness=True))
-

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -687,6 +687,15 @@ def test_validate_tlm_options_support_custom_eval_criteria() -> None:
     ):
         validate_tlm_options(options, support_custom_eval_criteria=False)
 
+    # Valid with disable_trustworthiness=True and custom_eval_criteria
+    validate_tlm_options({**options, "disable_trustworthiness": True}, support_custom_eval_criteria=True)
+    
+    # Invalid: disable_trustworthiness=True without custom_eval_criteria
+    with pytest.raises(ValidationError, match="^disable_trustworthiness is only supported when custom_eval_criteria is provided"):
+        validate_tlm_options({"disable_trustworthiness": True}, support_custom_eval_criteria=True)
+
+    with pytest.raises(ValidationError, match="^disable_trustworthiness is only supported when custom_eval_criteria is provided"):
+        validate_tlm_options({"disable_trustworthiness": True, "custom_eval_criteria": None}, support_custom_eval_criteria=True)
 
 def test_validate_rag_inputs_mixed_string_and_sequence() -> None:
     """Tests that validate_rag_inputs rejects mixed inputs where some are strings and others are sequences."""
@@ -798,3 +807,15 @@ def test_validate_rag_inputs_matching_lists() -> None:
     assert len(result) == list_length
     assert result[0] == "Q: query 1 C: context 1"
     assert result[1] == "Q: query 2 C: context 2"
+
+
+# def test_disable_trustworthiness_without_custom_criteria_raises_error(tlm_api_key: str) -> None:
+#     """Test that disable_trustworthiness=True without custom_eval_criteria raises ValueError."""
+#     with pytest.raises(ValueError) as exc_info:
+#         tlm = TLM(api_key=tlm_api_key, options=TLMOptions(disable_trustworthiness=True))
+#     assert "Trustworthiness is disabled but no alternative evaluation criteria was provided" in str(exc_info.value)
+
+# def test_disable_trustworthiness_with_custom_criteria_works(tlm_api_key: str) -> None:
+#     """Test that disable_trustworthiness=True with custom_eval_criteria works normally."""
+#     tlm = TLM(api_key=tlm_api_key, options=TLMOptions(disable_trustworthiness=True, custom_eval_criteria=[{"name": "test", "criteria": "test criteria"}]))
+#     assert tlm is not None


### PR DESCRIPTION

This adds a `disable_trustworthiness` parameter to `TLMOptions`. It allows users to disable trustworthiness scoring as long as custom Evals are configured to run. This should reduce computational overhead when only custom evaluation criteria are needed.

E.g. for TrustworthyRAG:

```python
from cleanlab_tlm import TrustworthyRAG

tlm = TrustworthyRAG(options={"disable_trustworthiness": True})

response = tlm.generate(
    query="What is the capital of France?",
    context="France is a country in Western Europe. Its capital is Paris, which is known for the Eiffel Tower."
)

print(response)
```

prints out (see the `"trustworthiness" key):

```
{'response': 'The capital of France is Paris.', 'trustworthiness': {'score': None}, 'context_sufficiency': {'score': 0.9975124378112403}, 'response_groundedness': {'score': 0.99751243781117}, 'response_helpfulness': {'score': 0.9975124378110827}, 'query_ease': {'score': 0.9975124378112539}}
```


The same works for TLM:


```python
from cleanlab_tlm import TLM

tlm = TLM(options={"disable_trustworthiness": True, "custom_eval_criteria": [{"name": "test", "criteria": "test criteria"}]})

response = tlm.prompt("What is the capital of France?")

print(response)
```

```
{'response': 'The capital of France is Paris.', 'trustworthiness_score': None, 'log': {'custom_eval_criteria': [{'name': 'test', 'score': 0.997512437816086}]}}
```