### PR TITLE
validate when explanations logging is supported or not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.34] - 2025-09-24
+
+### Added
+
+- Validate when explanations logging is supported or not
+
 ## [1.1.33] - 2025-09-23
 
 ### Fixed
@@ -355,7 +361,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Release of the Cleanlab TLM Python client.
 
-[Unreleased]: https://github.com/cleanlab/cleanlab-tlm/compare/v1.1.33...HEAD
+[Unreleased]: https://github.com/cleanlab/cleanlab-tlm/compare/v1.1.34...HEAD
+[1.1.34]: https://github.com/cleanlab/cleanlab-tlm/compare/v1.1.33...v1.1.34
 [1.1.33]: https://github.com/cleanlab/cleanlab-tlm/compare/v1.1.32...v1.1.33
 [1.1.32]: https://github.com/cleanlab/cleanlab-tlm/compare/v1.1.31...v1.1.32
 [1.1.31]: https://github.com/cleanlab/cleanlab-tlm/compare/v1.1.30...v1.1.31

--- a/src/cleanlab_tlm/__about__.py
+++ b/src/cleanlab_tlm/__about__.py
@@ -1,2 +1,2 @@
 # SPDX-License-Identifier: MIT
-__version__ = "1.1.33"
+__version__ = "1.1.34"

--- a/src/cleanlab_tlm/internal/constants.py
+++ b/src/cleanlab_tlm/internal/constants.py
@@ -5,6 +5,7 @@ from cleanlab_tlm.internal.types import Task, TLMQualityPreset
 _VALID_TLM_QUALITY_PRESETS: list[str] = ["best", "high", "medium", "low", "base"]
 _VALID_TLM_QUALITY_PRESETS_CHAT_COMPLETIONS: list[str] = ["medium", "low", "base"]
 _DEFAULT_TLM_QUALITY_PRESET: TLMQualityPreset = "medium"
+_QUALITY_PRESETS_W_CONSISTENCY_SAMPLES: set[str] = {"best", "high"}  # Must also apply to TrustworthyRAG
 _DEFAULT_TLM_MAX_TOKENS: int = 512
 _VALID_TLM_MODELS: list[str] = [
     "gpt-3.5-turbo-16k",
@@ -38,6 +39,17 @@ _VALID_TLM_MODELS: list[str] = [
     "nova-pro",
 ]
 _TLM_DEFAULT_MODEL: str = "gpt-4.1-mini"
+_HIDDEN_REASONING_MODELS: set[str] = {
+    "o1-preview",
+    "o1",
+    "o1-mini",
+    "o3",
+    "o3-mini",
+    "o4-mini",
+    "gpt-5",
+    "gpt-5-mini",
+    "gpt-5-nano",
+}
 _TLM_DEFAULT_CONTEXT_LIMIT: int = 70000
 _VALID_TLM_TASKS: set[str] = {task.value for task in Task}
 TLM_TASK_SUPPORTING_CONSTRAIN_OUTPUTS: set[Task] = {
@@ -95,3 +107,7 @@ _TLM_EVAL_CRITERIA_KEY: str = "criteria"
 _TLM_EVAL_QUERY_IDENTIFIER_KEY: str = "query_identifier"
 _TLM_EVAL_CONTEXT_IDENTIFIER_KEY: str = "context_identifier"
 _TLM_EVAL_RESPONSE_IDENTIFIER_KEY: str = "response_identifier"
+
+# Values that wont support logging explanation by default
+_REASONING_EFFORT_UNSUPPORTED_EXPLANATION_LOGGING: set[str] = {"none", "minimal"}
+_QUALITY_PRESETS_UNSUPPORTED_EXPLANATION_LOGGING: set[str] = {"low", "base"}  # For regular TLM not TrustworthyRAG

--- a/src/cleanlab_tlm/internal/validation.py
+++ b/src/cleanlab_tlm/internal/validation.py
@@ -249,7 +249,7 @@ def _validate_trustworthy_rag_options(options: Optional[TLMOptions], initialized
         )
 
 
-def validate_logging(options: Optional[TLMOptions], quality_preset: str, subclass: str):
+def validate_logging(options: Optional[TLMOptions], quality_preset: str, subclass: str) -> None:
     """If user asks to log explanation, then either:
     ensure the specified TLM configuration supports this (return early), or otherwise raise informative error.
 

--- a/src/cleanlab_tlm/tlm.py
+++ b/src/cleanlab_tlm/tlm.py
@@ -41,6 +41,7 @@ from cleanlab_tlm.internal.validation import (
     tlm_explanation_format_tlm_result,
     tlm_prompt_process_and_validate_kwargs,
     tlm_score_process_response_and_kwargs,
+    validate_logging,
     validate_tlm_prompt,
     validate_tlm_prompt_response,
 )
@@ -117,6 +118,7 @@ class TLM(BaseTLM):
         )
 
         # TLM-specific initialization
+        validate_logging(options=options, quality_preset=quality_preset, subclass="TLM")
         if task not in _VALID_TLM_TASKS:
             raise ValidationError(f"Invalid task {task} -- must be one of {_VALID_TLM_TASKS}")
 

--- a/src/cleanlab_tlm/utils/rag.py
+++ b/src/cleanlab_tlm/utils/rag.py
@@ -44,6 +44,7 @@ from cleanlab_tlm.internal.validation import (
     _validate_trustworthy_rag_options,
     tlm_explanation_format_trustworthy_rag_result,
     tlm_score_process_response_and_kwargs,
+    validate_logging,
     validate_rag_inputs,
 )
 
@@ -134,6 +135,7 @@ class TrustworthyRAG(BaseTLM):
             self._evals = evals
 
         _validate_trustworthy_rag_options(options=options, initialized_evals=self._evals)
+        validate_logging(options=options, quality_preset=quality_preset, subclass="TrustworthyRAG")
 
         # Optional per-eval tool call overrides
         # These are name-based include/exclude sets used only in the _handle_tool_call_filtering decorator

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,12 +83,17 @@ def tlm_dict(tlm_api_key: str) -> dict[str, Any]:
             tlm_dict[quality_preset][model] = {}
             task = random.choice(list(_VALID_TLM_TASKS))
             options = _get_options_dictionary(model)
-            tlm_dict[quality_preset][model]["tlm"] = TLM(
-                quality_preset=quality_preset,
-                task=task,
-                api_key=tlm_api_key,
-                options=options,
-            )
+            try:
+                tlm_dict[quality_preset][model]["tlm"] = TLM(
+                    quality_preset=quality_preset,
+                    task=task,
+                    api_key=tlm_api_key,
+                    options=options,
+                )
+            except ValueError as e:
+                if "does not support logged explanations" not in str(e):
+                    raise ValueError(str(e))
+
             tlm_dict[quality_preset][model]["tlm_no_options"] = TLM(
                 quality_preset=quality_preset,
                 task=task,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,10 +80,10 @@ def tlm_dict(tlm_api_key: str) -> dict[str, Any]:
     for quality_preset in TLMQualityPreset.__args__:  # type: ignore
         tlm_dict[quality_preset] = {}
         for model in _VALID_TLM_MODELS:
-            tlm_dict[quality_preset][model] = {}
-            task = random.choice(list(_VALID_TLM_TASKS))
-            options = _get_options_dictionary(model)
             try:
+                tlm_dict[quality_preset][model] = {}
+                task = random.choice(list(_VALID_TLM_TASKS))
+                options = _get_options_dictionary(model)
                 tlm_dict[quality_preset][model]["tlm"] = TLM(
                     quality_preset=quality_preset,
                     task=task,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,16 +90,21 @@ def tlm_dict(tlm_api_key: str) -> dict[str, Any]:
                     api_key=tlm_api_key,
                     options=options,
                 )
+                tlm_dict[quality_preset][model]["tlm_no_options"] = TLM(
+                    quality_preset=quality_preset,
+                    task=task,
+                    api_key=tlm_api_key,
+                )
+                tlm_dict[quality_preset][model]["options"] = options
             except ValueError as e:
-                if "does not support logged explanations" not in str(e):
+                if (  # only acceptable case of error is if log=['explanation'] with unsupported configurations
+                    ("does not support logged explanations" not in str(e))
+                    or (options is None)
+                    or ("log" not in options)
+                    or ("explanation" not in options.get("log", []))
+                ):
                     raise ValueError(str(e))
 
-            tlm_dict[quality_preset][model]["tlm_no_options"] = TLM(
-                quality_preset=quality_preset,
-                task=task,
-                api_key=tlm_api_key,
-            )
-            tlm_dict[quality_preset][model]["options"] = options
     return tlm_dict
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,10 +84,13 @@ def tlm_dict(tlm_api_key: str) -> dict[str, Any]:
             tlm_dict[quality_preset][model] = {}
             task = random.choice(list(_VALID_TLM_TASKS))
             options = _get_options_dictionary(model)
-            try:  # ensure valid options/preset/model configuration
+            try:  # ensure valid options/preset/model configuration for logging
                 validate_logging(options=options, quality_preset=quality_preset, subclass="TLM")
-            except ValueError:
-                options["log"].remove("explanation")
+            except ValueError as e:
+                if "does not support logged explanations" in str(e):
+                    options["log"].remove("explanation")
+                else:
+                    raise ValueError(e)
 
             tlm_dict[quality_preset][model]["tlm"] = TLM(
                 quality_preset=quality_preset,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,6 +89,8 @@ def tlm_dict(tlm_api_key: str) -> dict[str, Any]:
             except ValueError as e:
                 if "does not support logged explanations" in str(e):
                     options["log"].remove("explanation")
+                    if len(options["log"]) == 0:
+                        del options["log"]  # log cannot be empty list
                 else:
                     raise ValueError(e)
 

--- a/tests/test_chat_completions.py
+++ b/tests/test_chat_completions.py
@@ -283,7 +283,7 @@ def test_tlm_chat_completion_structured_output_per_field_scoring() -> None:
     # test per_field_score
     assert len(score["log"]["per_field_score"]) == 2  # noqa: PLR2004
     assert {"steps", "final_answer"} == set(score["log"]["per_field_score"].keys())
-    assert tlm_chat.get_untrustworthy_fields(response=response, tlm_result=score) == ["final_answer"]
+    assert "final_answer" in tlm_chat.get_untrustworthy_fields(response=response, tlm_result=score)
 
 
 def test_tlm_chat_completion_score_invalid_response() -> None:

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -892,6 +892,20 @@ def test_validate_logging(tlm_api_key: str) -> None:
     TLM(api_key=tlm_api_key, quality_preset="best", options={"log": ["explanation"], "reasoning_effort": "none"})
     TLM(api_key=tlm_api_key, quality_preset="high", options={"log": ["explanation"], "reasoning_effort": "none"})
     TLM(api_key=tlm_api_key, quality_preset="base", options={"log": ["explanation"], "num_consistency_samples": 8})
+    TLM(
+        api_key=tlm_api_key,
+        quality_preset="best",
+        options={"log": ["explanation"], "num_self_reflections": 0},
+    )
+    TLM(
+        api_key=tlm_api_key,
+        quality_preset="low",
+        options={
+            "log": ["explanation"],
+            "num_self_reflections": 0,
+            "num_consistency_samples": 4,
+        },
+    )
     TLM(api_key=tlm_api_key, options={"model": "gpt-5-mini"})
 
     # Settings that should error:
@@ -904,6 +918,39 @@ def test_validate_logging(tlm_api_key: str) -> None:
             api_key=tlm_api_key,
             quality_preset="best",
             options={"log": ["explanation"], "reasoning_effort": "none", "num_consistency_samples": 0},
+        )
+    with pytest.raises(ValueError, match="does not support logged explanations"):
+        TLM(
+            api_key=tlm_api_key,
+            options={"log": ["explanation"], "num_self_reflections": 0},
+        )
+
+    with (
+        pytest.warns(DeprecationWarning),
+        pytest.raises(ValueError, match="does not support logged explanations"),
+    ):
+        TLM(
+            api_key=tlm_api_key,
+            options={"log": ["explanation"], "use_self_reflection": False},
+        )
+    with pytest.raises(ValueError, match="does not support logged explanations"):
+        TLM(
+            api_key=tlm_api_key,
+            quality_preset="best",
+            options={
+                "log": ["explanation"],
+                "num_self_reflections": 0,
+                "num_consistency_samples": 0,
+            },
+        )
+    with pytest.raises(ValueError, match="does not support logged explanations"):
+        TLM(
+            api_key=tlm_api_key,
+            options={
+                "log": ["explanation"],
+                "reasoning_effort": "high",
+                "num_self_reflections": 0,
+            },
         )
     with pytest.raises(ValueError, match="does not support logged explanations"):
         TLM(api_key=tlm_api_key, options={"log": ["explanation"], "model": "gpt-5-mini"})
@@ -920,4 +967,24 @@ def test_validate_logging(tlm_api_key: str) -> None:
     with pytest.raises(ValueError, match="does not support logged explanations"):
         TrustworthyRAG(
             api_key=tlm_api_key, quality_preset="best", options={"log": ["explanation"], "num_consistency_samples": 0}
+        )
+    with pytest.raises(ValueError, match="does not support logged explanations"):
+        TrustworthyRAG(
+            api_key=tlm_api_key,
+            options={
+                "log": ["explanation"],
+                "reasoning_effort": "high",
+                "num_self_reflections": 0,
+            },
+        )
+    with pytest.raises(ValueError, match="does not support logged explanations"):
+        TrustworthyRAG(
+            api_key=tlm_api_key,
+            quality_preset="best",
+            options={
+                "log": ["explanation"],
+                "reasoning_effort": "high",
+                "num_self_reflections": 0,
+                "num_consistency_samples": 0,
+            },
         )

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -884,6 +884,7 @@ def test_disable_trustworthiness_with_custom_criteria_works_rag(tlm_api_key: str
     TrustworthyRAG(api_key=tlm_api_key, options={"disable_trustworthiness": True})
 
 
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_validate_logging(tlm_api_key: str) -> None:
     """Test validate_logging() method errors at the right times."""
     # Settings that should not raise error:
@@ -925,10 +926,7 @@ def test_validate_logging(tlm_api_key: str) -> None:
             options={"log": ["explanation"], "num_self_reflections": 0},
         )
 
-    with (
-        pytest.warns(DeprecationWarning),
-        pytest.raises(ValueError, match="does not support logged explanations"),
-    ):
+    with pytest.raises(ValueError, match="does not support logged explanations"):
         TLM(
             api_key=tlm_api_key,
             options={"log": ["explanation"], "use_self_reflection": False},

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -875,14 +875,49 @@ def test_disable_trustworthiness_with_custom_criteria_works(tlm_api_key: str) ->
 
 def test_disable_trustworthiness_without_custom_criteria_raises_error_rag(tlm_api_key: str) -> None:
     """Test that disable_trustworthiness=True without custom_eval_criteria raises ValueError for TrustworthyRAG."""
-    from cleanlab_tlm.utils.rag import TrustworthyRAG
-
     with pytest.raises(ValidationError, match="^When disable_trustworthiness=True in TrustworthyRAG"):
         TrustworthyRAG(evals=[], api_key=tlm_api_key, options={"disable_trustworthiness": True})
 
 
 def test_disable_trustworthiness_with_custom_criteria_works_rag(tlm_api_key: str) -> None:
     """Test that disable_trustworthiness=True with custom_eval_criteria works normally for TrustworthyRAG."""
-    from cleanlab_tlm.utils.rag import TrustworthyRAG
-
     TrustworthyRAG(api_key=tlm_api_key, options={"disable_trustworthiness": True})
+
+
+def test_validate_logging(tlm_api_key: str) -> None:
+    """Test validate_logging() method errors at the right times."""
+    # Settings that should not raise error:
+    TLM(api_key=tlm_api_key)
+    TLM(api_key=tlm_api_key, options={"log": ["explanation"]})
+    TLM(api_key=tlm_api_key, quality_preset="best", options={"log": ["explanation"], "reasoning_effort": "none"})
+    TLM(api_key=tlm_api_key, quality_preset="high", options={"log": ["explanation"], "reasoning_effort": "none"})
+    TLM(api_key=tlm_api_key, quality_preset="base", options={"log": ["explanation"], "num_consistency_samples": 8})
+    TLM(api_key=tlm_api_key, options={"model": "gpt-5-mini"})
+
+    # Settings that should error:
+    with pytest.raises(ValueError, match="does not support logged explanations"):
+        TLM(api_key=tlm_api_key, quality_preset="low", options={"log": ["explanation"]})
+    with pytest.raises(ValueError, match="does not support logged explanations"):
+        TLM(api_key=tlm_api_key, quality_preset="base", options={"log": ["explanation"]})
+    with pytest.raises(ValueError, match="does not support logged explanations"):
+        TLM(
+            api_key=tlm_api_key,
+            quality_preset="best",
+            options={"log": ["explanation"], "reasoning_effort": "none", "num_consistency_samples": 0},
+        )
+    with pytest.raises(ValueError, match="does not support logged explanations"):
+        TLM(api_key=tlm_api_key, options={"log": ["explanation"], "model": "gpt-5-mini"})
+
+    # Settings that should not raise error:
+    TrustworthyRAG(api_key=tlm_api_key)
+    TrustworthyRAG(api_key=tlm_api_key, options={"log": ["explanation"], "num_consistency_samples": 5})
+    TrustworthyRAG(api_key=tlm_api_key, options={"log": ["explanation"], "reasoning_effort": "high"})
+    TrustworthyRAG(api_key=tlm_api_key, quality_preset="best", options={"log": ["explanation"]})
+
+    # Settings that should error:
+    with pytest.raises(ValueError, match="does not support logged explanations"):
+        TrustworthyRAG(api_key=tlm_api_key, options={"log": ["explanation"]})
+    with pytest.raises(ValueError, match="does not support logged explanations"):
+        TrustworthyRAG(
+            api_key=tlm_api_key, quality_preset="best", options={"log": ["explanation"], "num_consistency_samples": 0}
+        )


### PR DESCRIPTION
Now when user instantiates TLM/TRAG with configuration that won't support logging explanation, they get informative error message:

```
ValueError(
        "Your TLM configuration does not support logged explanations.  "
        "Please remove 'explanation' from your specified `log`, and instead use the `get_explanation()` method after computing trust scores."
    )
```

New behavior introduced in this PR:

```
### For TLM: ###

# Settings that should not raise error:
tlm = TLM()
tlm = TLM(options={"log": ["explanation"]})
tlm = TLM(quality_preset="best", options={"log": ["explanation"], "reasoning_effort": "none"})
tlm = TLM(quality_preset="high", options={"log": ["explanation"], "reasoning_effort": "none"})
tlm = TLM(quality_preset="base", options={"log": ["explanation"], "num_consistency_samples": 8})
tlm = TLM(options={"model": "gpt-5-mini"})


# Settings that should error:
tlm = TLM(quality_preset="low", options={"log": ["explanation"]})
tlm = TLM(quality_preset="base", options={"log": ["explanation"]})
tlm = TLM(quality_preset="best", options={"log": ["explanation"], "reasoning_effort": "none", "num_consistency_samples": 0})
tlm = TLM(options={"log": ["explanation"], "model": "gpt-5-mini"})


# This code is would've previously given a fallback Explanation in the settings that now error
output = tlm.get_trustworthiness_score(prompt, response)
print(f'Trustworthiness Score: {output["trustworthiness_score"]}\n')
print(f'Explanation: {output["log"]["explanation"]}')


# In the settings that now error, user can still run this:
output = tlm.get_trustworthiness_score(prompt, response)
print(f'Trustworthiness Score: {output["trustworthiness_score"]}\n')
print(f'Explanation: {tlm.get_explanation(prompt=prompt, response=response, tlm_result=output)}')


### For TRAG: ###

# Settings that should not raise error:
trag = TrustworthyRAG()
trag = TrustworthyRAG(options={"log": ["explanation"], "num_consistency_samples": 5})
trag = TrustworthyRAG(options={"log": ["explanation"], "reasoning_effort": "high"})
trag = TrustworthyRAG(quality_preset="best", options={"log": ["explanation"]})



# Settings that should error:
trag = TrustworthyRAG(options={"log": ["explanation"]})
trag = TrustworthyRAG(quality_preset="best", options={"log": ["explanation"], "num_consistency_samples": 0})

# This code is would've previously given a fallback Explanation in the settings that now error
output = trag.score(query=prompt, context="", response=response)
print(f'Trustworthiness Score: {output["trustworthiness"]}\n')
print(f'Explanation: {output["trustworthiness"]["log"]["explanation"]}')


# In the settings that now error, user can still run this:
output = trag.score(query=prompt, context="", response=response)
print(f'Trustworthiness Score: {output["trustworthiness"]}\n')
print(f'Explanation: {trag.get_explanation(query=prompt, context="", response=response, tlm_result=output)}')
```