### PR TITLE
added score_async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added 
+
+- Add `score_async` API for TLMChatCompletion
+
 ## [1.1.34] - 2025-09-24
 
 ### Added

--- a/src/cleanlab_tlm/utils/chat_completions.py
+++ b/src/cleanlab_tlm/utils/chat_completions.py
@@ -85,18 +85,15 @@ class TLMChatCompletion(BaseTLM):
         Returns:
             TLMScore: A dict containing the trustworthiness score and optional logs
         """
-        return self._event_loop.run_until_complete(
-            self.score_async(response=response, **openai_kwargs)
-        )
+        return self._event_loop.run_until_complete(self.score_async(response=response, **openai_kwargs))
 
     async def score_async(
         self,
         *,
         response: "ChatCompletion",
         **openai_kwargs: Any,
-) -> TLMScore:
+    ) -> TLMScore:
         """Asynchronously score the trustworthiness of an OpenAI ChatCompletion response.
-        
         This method is similar to the [`score()`](#method-score) method but operates asynchronously,
         allowing for non-blocking concurrent operations.
 

--- a/src/cleanlab_tlm/utils/chat_completions.py
+++ b/src/cleanlab_tlm/utils/chat_completions.py
@@ -85,6 +85,31 @@ class TLMChatCompletion(BaseTLM):
         Returns:
             TLMScore: A dict containing the trustworthiness score and optional logs
         """
+        return self._event_loop.run_until_complete(
+            self.score_async(response=response, **openai_kwargs)
+        )
+
+    async def score_async(
+        self,
+        *,
+        response: "ChatCompletion",
+        **openai_kwargs: Any,
+) -> TLMScore:
+        """Asynchronously score the trustworthiness of an OpenAI ChatCompletion response.
+        
+        This method is similar to the [`score()`](#method-score) method but operates asynchronously,
+        allowing for non-blocking concurrent operations.
+
+        Use this method if you want to score multiple ChatCompletion responses concurrently
+        without blocking the execution of other operations.
+
+        Args:
+            response (ChatCompletion): The OpenAI ChatCompletion response object to evaluate
+            **openai_kwargs (Any): The original kwargs passed to OpenAI's create() method, must include 'messages'
+
+        Returns:
+            TLMScore: A dict containing the trustworthiness score and optional logs
+        """
         try:
             from openai.lib._parsing._completions import type_to_response_format_param
         except ImportError as e:
@@ -113,15 +138,13 @@ class TLMChatCompletion(BaseTLM):
             combined_kwargs["response_format"] = type_to_response_format_param(combined_kwargs["response_format"])
             return cast(
                 TLMScore,
-                self._event_loop.run_until_complete(
-                    asyncio.wait_for(
-                        tlm_chat_completions_score(
-                            api_key=self._api_key,
-                            response=response,
-                            **combined_kwargs,
-                        ),
-                        timeout=self._timeout,
-                    )
+                await asyncio.wait_for(
+                    tlm_chat_completions_score(
+                        api_key=self._api_key,
+                        response=response,
+                        **combined_kwargs,
+                    ),
+                    timeout=self._timeout,
                 ),
             )
 
@@ -131,7 +154,7 @@ class TLMChatCompletion(BaseTLM):
         prompt_text = _form_prompt_chat_completions_api(messages, tools)
         response_text = form_response_string_chat_completions(response=response)
 
-        return cast(TLMScore, self._tlm.get_trustworthiness_score(prompt_text, response_text))
+        return cast(TLMScore, await self._tlm.get_trustworthiness_score_async(prompt_text, response_text))
 
     def get_explanation(
         self,

--- a/tests/test_chat_completions.py
+++ b/tests/test_chat_completions.py
@@ -1,6 +1,6 @@
 import asyncio
 import json
-from typing import Callable, Any
+from typing import Any, Callable
 
 import pytest
 from openai.types.chat import ChatCompletion, ChatCompletionMessage
@@ -33,8 +33,7 @@ def _run_score_sync_or_async(
     """Runs either sync or async score method based on is_async parameter."""
     if is_async:
         return asyncio.run(tlm_chat.score_async(response=response, **openai_kwargs))
-    else:
-        return tlm_chat.score(response=response, **openai_kwargs)
+    return tlm_chat.score(response=response, **openai_kwargs)
 
 
 def test_get_model_name() -> None:
@@ -359,7 +358,9 @@ def test_tlm_chat_completion_score_missing_messages() -> None:
     ids=["bad_arguments", "good_arguments"],
 )
 @pytest.mark.parametrize("is_async", [False, True], ids=["sync", "async"])
-def test_tlm_chat_completion_score_tool_calls(arguments: str, condition: Callable[[TLMScore], bool], is_async: bool) -> None:
+def test_tlm_chat_completion_score_tool_calls(
+    arguments: str, condition: Callable[[TLMScore], bool], is_async: bool
+) -> None:
     tlm_chat = TLMChatCompletion()
 
     openai_kwargs = {


### PR DESCRIPTION
TLMChatCompletion.score is blocking. Added score_async which is non-blocking that will be helpful also for benchmarking (batching).

Tested async works in [sandbox](https://github.com/cleanlab/sandbox/blob/main/gordonlim/TLM-Chat-Cmpl-score-async/tests.ipynb).